### PR TITLE
Add compact replay scripts and generated engine tests

### DIFF
--- a/src/gameScripts.test.ts
+++ b/src/gameScripts.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  battlegroundDefinitions,
+  cardDefinitions,
+  pathDefinitions,
+  turnOrder,
+} from "./data";
+import { canPlayTo, createGame, getCardDefinition, validateState } from "./game";
+import {
+  arrangeGame,
+  exportGameScript,
+  renderReplay,
+  resolveCardRef,
+  runGameScript,
+} from "./gameScripts";
+import type { CardDefinition, Faction, GameState, PlayerId, PlayDestination } from "./types";
+
+const seedCases = Array.from({ length: 180 }, (_, index) => `mass-seed-${index + 1}`);
+const ringReplayCases = seedCases.flatMap((seed) =>
+  turnOrder.map((player) => ({ name: `${seed}:${player}:ring`, seed, player })),
+);
+const cycleReplayCases = seedCases.flatMap((seed) =>
+  turnOrder.map((player) => ({ name: `${seed}:${player}:cycle`, seed, player })),
+);
+const combatReplayCases = seedCases.map((seed) => ({ name: `${seed}:combat`, seed }));
+
+const legalityCases = cardDefinitions.flatMap((card) =>
+  (["reserve", "path", "battleground"] satisfies readonly PlayDestination[]).map(
+    (destination) => ({
+      name: `${card.owner}:${card.id}:${destination}`,
+      card,
+      destination,
+    }),
+  ),
+);
+
+const reservePlayCases = cardDefinitions
+  .filter((card) => card.type !== "event")
+  .map((card) => ({ name: `${card.owner}:${card.id}:reserve-play`, card }));
+
+const lastCardCases = cardDefinitions
+  .filter((card) => card.type !== "event")
+  .map((card) => ({ name: `${card.owner}:${card.id}:last-card`, card }));
+
+const generatedCaseCount =
+  ringReplayCases.length +
+  cycleReplayCases.length +
+  combatReplayCases.length +
+  legalityCases.length +
+  reservePlayCases.length +
+  lastCardCases.length;
+
+describe("compact game scripts", () => {
+  it("defines at least 1000 generated engine cases", () => {
+    expect(generatedCaseCount).toBeGreaterThanOrEqual(1000);
+  });
+
+  it("exports and renders a compact replay", () => {
+    const result = runGameScript({
+      name: "example replay",
+      seed: "example-replay",
+      arrange: {
+        players: {
+          aragorn: {
+            hand: ["anduril-46", "strider-44"],
+          },
+        },
+      },
+      steps: [
+        { action: "selectPlayer", player: "aragorn" },
+        { action: "play", player: "aragorn", card: "anduril-46", destination: "reserve" },
+      ],
+    });
+
+    expect(result.frames).toHaveLength(3);
+    expect(result.frames.every((frame) => frame.errors.length === 0)).toBe(true);
+    expect(renderReplay(result)).toContain("aragorn play anduril-46 to reserve");
+    expect(exportGameScript(result.script)).toContain('"seed": "example-replay"');
+  });
+
+  it.each(ringReplayCases)("replays ring-token draw: $name", ({ seed, player }) => {
+    const result = runGameScript({
+      seed,
+      steps: [{ action: "ring", player }],
+    });
+
+    expect(result.frames.every((frame) => frame.errors.length === 0)).toBe(true);
+    expect(result.finalState.players[player].usedRingToken).toBe(true);
+    expect(result.finalState.log.at(-1)?.message).toContain("used a ring token");
+  });
+
+  it.each(cycleReplayCases)("replays cycling from hand: $name", ({ seed, player }) => {
+    const initial = createGame(seed);
+    const card = mustHave(initial.players[player].hand[0]);
+    const result = runGameScript({
+      seed,
+      steps: [{ action: "cycle", player, card }],
+    });
+
+    expect(result.frames.every((frame) => frame.errors.length === 0)).toBe(true);
+    expect(result.finalState.players[player].hand).not.toContain(card);
+    expect(result.finalState.players[player].cycle).toContain(card);
+  });
+
+  it.each(combatReplayCases)("keeps combat replay state valid: $name", ({ seed }) => {
+    const initial = createGame(seed);
+    const pathPlay = firstPlayable(initial, "frodo", "path");
+    const battlegroundPlay = firstPlayable(initial, "saruman", "battleground");
+    const steps = [
+      ...(pathPlay === null
+        ? []
+        : [{ action: "play" as const, player: "frodo" as const, card: pathPlay, destination: "path" as const }]),
+      ...(battlegroundPlay === null
+        ? []
+        : [
+            {
+              action: "play" as const,
+              player: "saruman" as const,
+              card: battlegroundPlay,
+              destination: "battleground" as const,
+            },
+          ]),
+      { action: "resolveCombat" as const },
+    ];
+    const result = runGameScript({ seed, steps });
+
+    expect(result.frames.every((frame) => frame.errors.length === 0)).toBe(true);
+    expect(result.finalState.round).toBe(2);
+    expect(result.finalState.currentPathNumber).toBe(2);
+  });
+
+  it.each(legalityCases)("checks destination legality: $name", ({ card, destination }) => {
+    const state = arrangeForCard(card);
+    const instanceId = resolveCardRef(state, card.owner, card.id);
+
+    expect(canPlayTo(state, card.owner, instanceId, destination)).toBe(
+      expectedLegality(state, card, destination),
+    );
+  });
+
+  it.each(reservePlayCases)("replays reserve play and payment: $name", ({ card }) => {
+    const cost = costCardFor(card);
+    const state = arrangeGame(createGame(`reserve-${card.id}`), {
+      players: {
+        [card.owner]: {
+          hand: [card.id, cost.id],
+          draw: [],
+          cycle: [],
+        },
+      },
+    });
+    const result = runGameScript({
+      seed: `reserve-${card.id}`,
+      arrange: {
+        players: {
+          [card.owner]: {
+            hand: [card.id, cost.id],
+            draw: [],
+            cycle: [],
+          },
+        },
+      },
+      steps: [
+        {
+          action: "play",
+          player: card.owner,
+          card: card.id,
+          destination: "reserve",
+          cost: cost.id,
+        },
+      ],
+    });
+    const played = resolveCardRef(state, card.owner, card.id);
+    const paid = resolveCardRef(state, card.owner, cost.id);
+
+    expect(result.finalState.players[card.owner].reserve).toContain(played);
+    expect(result.finalState.players[card.owner].cycle).toContain(paid);
+    expect(result.frames.every((frame) => frame.errors.length === 0)).toBe(true);
+  });
+
+  it.each(lastCardCases)("replays last-card forsake fallback: $name", ({ card }) => {
+    const forsaken = costCardFor(card);
+    const state = arrangeGame(createGame(`last-${card.id}`), {
+      players: {
+        [card.owner]: {
+          hand: [card.id],
+          draw: [forsaken.id],
+          cycle: [],
+        },
+      },
+    });
+    const result = runGameScript({
+      seed: `last-${card.id}`,
+      arrange: {
+        players: {
+          [card.owner]: {
+            hand: [card.id],
+            draw: [forsaken.id],
+            cycle: [],
+          },
+        },
+      },
+      steps: [{ action: "play", player: card.owner, card: card.id, destination: "reserve" }],
+    });
+    const played = resolveCardRef(state, card.owner, card.id);
+    const eliminated = resolveCardRef(state, card.owner, forsaken.id);
+
+    expect(result.finalState.players[card.owner].reserve).toContain(played);
+    expect(result.finalState.players[card.owner].eliminated).toContain(eliminated);
+    expect(result.frames.every((frame) => frame.errors.length === 0)).toBe(true);
+  });
+});
+
+function arrangeForCard(card: CardDefinition): GameState {
+  const cost = costCardFor(card);
+  const activePath = pathDefinitions.find((path) =>
+    card.allowedPaths.includes(path.pathNumber),
+  ) ?? pathDefinitions[0];
+  const activeBattleground =
+    battlegroundDefinitions.find((battleground) => {
+      return battlegroundFactions(battleground).includes(card.faction);
+    }) ?? battlegroundDefinitions[0];
+
+  return arrangeGame(createGame(`legality-${card.id}`), {
+    activePath: { id: activePath.id },
+    activeBattleground: { id: activeBattleground.id },
+    players: {
+      [card.owner]: {
+        hand: [card.id, cost.id],
+        draw: [],
+        cycle: [],
+      },
+    },
+  });
+}
+
+function expectedLegality(
+  state: GameState,
+  card: CardDefinition,
+  destination: PlayDestination,
+): boolean {
+  if (destination === "reserve") {
+    return card.type !== "event";
+  }
+  if (destination === "path") {
+    const path = pathDefinitions.find((candidate) => candidate.id === state.activePath?.id);
+    return (
+      path !== undefined &&
+      card.type === "character" &&
+      card.allowedPaths.includes(path.pathNumber)
+    );
+  }
+  const battleground = battlegroundDefinitions.find(
+    (candidate) => candidate.id === state.activeBattleground?.id,
+  );
+  return (
+    battleground !== undefined &&
+    card.type !== "event" &&
+    card.type !== "item" &&
+    battlegroundFactions(battleground).includes(card.faction)
+  );
+}
+
+function battlegroundFactions(
+  battleground: (typeof battlegroundDefinitions)[number],
+): readonly Faction[] {
+  return [...battleground.attackingFactions, ...battleground.defendingFactions];
+}
+
+function firstPlayable(
+  state: GameState,
+  player: PlayerId,
+  destination: "battleground" | "path",
+): string | null {
+  return (
+    state.players[player].hand.find((instanceId) =>
+      canPlayTo(state, player, instanceId, destination),
+    ) ?? null
+  );
+}
+
+function costCardFor(card: CardDefinition): CardDefinition {
+  const cost = cardDefinitions.find((candidate) => {
+    return candidate.owner === card.owner && candidate.id !== card.id;
+  });
+  if (cost === undefined) {
+    throw new Error(`No cost card available for ${card.id}`);
+  }
+  return cost;
+}
+
+function mustHave<T>(value: T | undefined): T {
+  if (value === undefined) {
+    throw new Error("Expected value to exist");
+  }
+  return value;
+}

--- a/src/gameScripts.ts
+++ b/src/gameScripts.ts
@@ -1,0 +1,388 @@
+import { battlegroundDefinitions, pathDefinitions, turnOrder } from "./data";
+import {
+  createGame,
+  cycleCard,
+  discardOversizedHands,
+  getCard,
+  getCardDefinition,
+  pass,
+  playCard,
+  resolveCombat,
+  selectCard,
+  selectPlayer,
+  usePlayerRingToken,
+  validateState,
+} from "./game";
+import type {
+  ActiveBattleground,
+  ActivePath,
+  GameState,
+  PlayerId,
+  PlayerState,
+  PlayDestination,
+  Side,
+} from "./types";
+
+type PlayerZone = "draw" | "hand" | "cycle" | "eliminated" | "reserve";
+
+export interface CompactGameScript {
+  readonly name?: string;
+  readonly seed: string;
+  readonly arrange?: CompactArrangement;
+  readonly steps?: readonly CompactStep[];
+}
+
+export interface CompactArrangement {
+  readonly round?: number;
+  readonly currentPathNumber?: number;
+  readonly activePlayer?: PlayerId;
+  readonly activePath?: CompactActivePath | null;
+  readonly activeBattleground?: CompactActiveBattleground | null;
+  readonly pathDeck?: readonly string[];
+  readonly battlegroundDecks?: Partial<Record<Side, readonly string[]>>;
+  readonly score?: Partial<Record<Side, number>>;
+  readonly players?: Partial<Record<PlayerId, Partial<Record<PlayerZone, readonly string[]>>>>;
+}
+
+export interface CompactActivePath {
+  readonly id: string;
+  readonly cards?: readonly string[];
+}
+
+export interface CompactActiveBattleground {
+  readonly id: string;
+  readonly cards?: readonly string[];
+  readonly attackTokens?: number;
+  readonly defenseTokens?: number;
+}
+
+export type CompactStep =
+  | { readonly action: "cycle"; readonly player: PlayerId; readonly card: string }
+  | { readonly action: "discardOversizedHands" }
+  | { readonly action: "pass" }
+  | {
+      readonly action: "play";
+      readonly player: PlayerId;
+      readonly card: string;
+      readonly destination: PlayDestination;
+      readonly cost?: string;
+    }
+  | { readonly action: "resolveCombat" }
+  | { readonly action: "ring"; readonly player: PlayerId }
+  | { readonly action: "selectCard"; readonly card: string | null }
+  | { readonly action: "selectPlayer"; readonly player: PlayerId };
+
+export interface ReplayFrame {
+  readonly step: number;
+  readonly label: string;
+  readonly state: GameState;
+  readonly errors: readonly string[];
+}
+
+export interface ReplayResult {
+  readonly script: CompactGameScript;
+  readonly frames: readonly ReplayFrame[];
+  readonly finalState: GameState;
+}
+
+export function runGameScript(script: CompactGameScript): ReplayResult {
+  let state = arrangeGame(createGame(script.seed), script.arrange);
+  const frames: ReplayFrame[] = [
+    { step: 0, label: "initial", state, errors: validateState(state) },
+  ];
+
+  for (const [index, step] of (script.steps ?? []).entries()) {
+    state = applyStep(state, step);
+    frames.push({
+      step: index + 1,
+      label: stepLabel(step),
+      state,
+      errors: validateState(state),
+    });
+  }
+
+  return { script, frames, finalState: state };
+}
+
+export function arrangeGame(state: GameState, arrangement: CompactArrangement = {}): GameState {
+  const resolvedActivePath = resolveActivePath(state, arrangement.activePath);
+  const resolvedActiveBattleground = resolveActiveBattleground(
+    state,
+    arrangement.activeBattleground,
+  );
+  let nextState: GameState = {
+    ...state,
+    round: arrangement.round ?? state.round,
+    currentPathNumber: arrangement.currentPathNumber ?? state.currentPathNumber,
+    activePlayer: arrangement.activePlayer ?? state.activePlayer,
+    activePath:
+      arrangement.activePath === undefined ? state.activePath : resolvedActivePath,
+    activeBattleground:
+      arrangement.activeBattleground === undefined
+        ? state.activeBattleground
+        : resolvedActiveBattleground,
+    pathDeck: arrangement.pathDeck ?? state.pathDeck,
+    battlegroundDecks: {
+      free: arrangement.battlegroundDecks?.free ?? state.battlegroundDecks.free,
+      shadow: arrangement.battlegroundDecks?.shadow ?? state.battlegroundDecks.shadow,
+    },
+    score: {
+      free: arrangement.score?.free ?? state.score.free,
+      shadow: arrangement.score?.shadow ?? state.score.shadow,
+    },
+  };
+
+  const placedCards = new Set<string>([
+    ...(nextState.activePath?.cards ?? []),
+    ...(nextState.activeBattleground?.cards ?? []),
+  ]);
+  const playerZoneOverrides: Partial<Record<PlayerId, Partial<Record<PlayerZone, readonly string[]>>>> =
+    {};
+
+  for (const playerId of turnOrder) {
+    const zones = arrangement.players?.[playerId];
+    if (zones === undefined) {
+      continue;
+    }
+    const resolvedZones = Object.fromEntries(
+      Object.entries(zones).map(([zone, cards]) => [
+        zone,
+        cards.map((card) => resolveCardRef(nextState, playerId, card)),
+      ]),
+    ) as Partial<Record<PlayerZone, readonly string[]>>;
+    playerZoneOverrides[playerId] = resolvedZones;
+    for (const cards of Object.values(resolvedZones)) {
+      for (const instanceId of cards) {
+        placedCards.add(instanceId);
+      }
+    }
+  }
+
+  nextState = {
+    ...nextState,
+    players: Object.fromEntries(
+      turnOrder.map((playerId) => {
+        const player = nextState.players[playerId];
+        const zones = playerZoneOverrides[playerId];
+        if (zones === undefined) {
+          const cleaned = removePlacedCards(player, placedCards);
+          return [playerId, cleaned];
+        }
+        const sweptCards = [
+          ...player.draw,
+          ...player.hand,
+          ...player.cycle,
+          ...player.reserve,
+        ].filter((instanceId) => !placedCards.has(instanceId));
+        const keptEliminated = player.eliminated.filter(
+          (instanceId) => !placedCards.has(instanceId),
+        );
+        return [
+          playerId,
+          {
+            ...player,
+            draw: zones.draw ?? [],
+            hand: zones.hand ?? [],
+            cycle: zones.cycle ?? [],
+            reserve: zones.reserve ?? [],
+            eliminated: zones.eliminated ?? [...keptEliminated, ...sweptCards],
+          } satisfies PlayerState,
+        ];
+      }),
+    ) as GameState["players"],
+  };
+
+  const errors = validateState(nextState);
+  if (errors.length > 0) {
+    throw new Error(`Invalid compact arrangement: ${errors.join("; ")}`);
+  }
+  return nextState;
+}
+
+export function applyStep(state: GameState, step: CompactStep): GameState {
+  switch (step.action) {
+    case "cycle":
+      return cycleCard(state, step.player, resolveCardRef(state, step.player, step.card));
+    case "discardOversizedHands":
+      return discardOversizedHands(state);
+    case "pass":
+      return pass(state);
+    case "play":
+      return playCard(
+        state,
+        step.player,
+        resolveCardRef(state, step.player, step.card),
+        step.destination,
+        step.cost === undefined ? undefined : resolveCardRef(state, step.player, step.cost),
+      );
+    case "resolveCombat":
+      return resolveCombat(state);
+    case "ring":
+      return usePlayerRingToken(state, step.player);
+    case "selectCard":
+      return selectCard(
+        state,
+        step.card === null ? null : resolveCardRef(state, state.selection.playerId, step.card),
+      );
+    case "selectPlayer":
+      return selectPlayer(state, step.player);
+  }
+}
+
+export function exportGameScript(script: CompactGameScript): string {
+  return JSON.stringify(sortForExport(script), null, 2);
+}
+
+export function renderReplay(result: ReplayResult): string {
+  return result.frames.map((frame) => renderFrame(frame)).join("\n");
+}
+
+export function renderFrame(frame: ReplayFrame): string {
+  const state = frame.state;
+  const activePath = state.activePath?.id ?? "-";
+  const activeBattleground = state.activeBattleground?.id ?? "-";
+  const zoneSummary = turnOrder
+    .map((playerId) => {
+      const player = state.players[playerId];
+      return `${playerId}:h${player.hand.length}/d${player.draw.length}/c${player.cycle.length}/r${player.reserve.length}/e${player.eliminated.length}`;
+    })
+    .join(" ");
+  const errors = frame.errors.length === 0 ? "ok" : `errors=${frame.errors.length}`;
+  return `${frame.step}. ${frame.label} | r${state.round} ${state.phase} ${state.activePlayer} score ${state.score.free}-${state.score.shadow} path=${activePath} bg=${activeBattleground} ${zoneSummary} ${errors}`;
+}
+
+export function resolveCardRef(
+  state: GameState,
+  playerId: PlayerId,
+  cardRef: string,
+): string {
+  if (state.cards[cardRef] !== undefined) {
+    return cardRef;
+  }
+
+  const normalized = normalizeTitle(cardRef);
+  const candidates = Object.values(state.cards).filter((card) => {
+    const definition = getCardDefinition(card.cardId);
+    return (
+      definition.owner === playerId &&
+      (definition.id === cardRef || normalizeTitle(definition.title) === normalized)
+    );
+  });
+  if (candidates.length !== 1) {
+    throw new Error(
+      `Expected exactly one ${playerId} card for "${cardRef}", found ${candidates.length}`,
+    );
+  }
+  return mustHave(candidates[0]).instanceId;
+}
+
+function resolveActivePath(
+  state: GameState,
+  activePath: CompactActivePath | null | undefined,
+): ActivePath | null {
+  if (activePath === undefined) {
+    return state.activePath;
+  }
+  if (activePath === null) {
+    return null;
+  }
+  if (!pathDefinitions.some((path) => path.id === activePath.id)) {
+    throw new Error(`Unknown path: ${activePath.id}`);
+  }
+  return {
+    id: activePath.id,
+    cards: activePath.cards?.map((card) => resolveAnyCardRef(state, card)) ?? [],
+  };
+}
+
+function resolveActiveBattleground(
+  state: GameState,
+  activeBattleground: CompactActiveBattleground | null | undefined,
+): ActiveBattleground | null {
+  if (activeBattleground === undefined) {
+    return state.activeBattleground;
+  }
+  if (activeBattleground === null) {
+    return null;
+  }
+  if (!battlegroundDefinitions.some((battleground) => battleground.id === activeBattleground.id)) {
+    throw new Error(`Unknown battleground: ${activeBattleground.id}`);
+  }
+  return {
+    id: activeBattleground.id,
+    cards: activeBattleground.cards?.map((card) => resolveAnyCardRef(state, card)) ?? [],
+    attackTokens: activeBattleground.attackTokens ?? 0,
+    defenseTokens: activeBattleground.defenseTokens ?? 0,
+  };
+}
+
+function resolveAnyCardRef(state: GameState, cardRef: string): string {
+  if (state.cards[cardRef] !== undefined) {
+    return cardRef;
+  }
+  const matches = Object.values(state.cards).filter((card) => {
+    const definition = getCardDefinition(card.cardId);
+    return definition.id === cardRef || normalizeTitle(definition.title) === normalizeTitle(cardRef);
+  });
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one card for "${cardRef}", found ${matches.length}`);
+  }
+  return mustHave(matches[0]).instanceId;
+}
+
+function removePlacedCards(player: PlayerState, placedCards: ReadonlySet<string>): PlayerState {
+  return {
+    ...player,
+    draw: player.draw.filter((instanceId) => !placedCards.has(instanceId)),
+    hand: player.hand.filter((instanceId) => !placedCards.has(instanceId)),
+    cycle: player.cycle.filter((instanceId) => !placedCards.has(instanceId)),
+    reserve: player.reserve.filter((instanceId) => !placedCards.has(instanceId)),
+    eliminated: player.eliminated.filter((instanceId) => !placedCards.has(instanceId)),
+  };
+}
+
+function stepLabel(step: CompactStep): string {
+  switch (step.action) {
+    case "cycle":
+      return `${step.player} cycle ${step.card}`;
+    case "discardOversizedHands":
+      return "discard oversized hands";
+    case "pass":
+      return "pass";
+    case "play":
+      return `${step.player} play ${step.card} to ${step.destination}`;
+    case "resolveCombat":
+      return "resolve combat";
+    case "ring":
+      return `${step.player} ring`;
+    case "selectCard":
+      return `select card ${step.card ?? "-"}`;
+    case "selectPlayer":
+      return `select player ${step.player}`;
+  }
+}
+
+function normalizeTitle(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function sortForExport(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortForExport(item));
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, sortForExport(nested)]),
+    );
+  }
+  return value;
+}
+
+function mustHave<T>(value: T | undefined): T {
+  if (value === undefined) {
+    throw new Error("Expected value to exist");
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary
- add a compact game script format for arranging, replaying, exporting, and rendering concise game transcripts
- add generated engine coverage for deterministic seeds, ring-token draws, cycling, combat replay, destination legality, reserve play costs, and last-card forsake fallback
- raise the Vitest suite to 2,238 passing tests, including an explicit guard that generated engine cases stay above 1,000

## Verification
- npm run typecheck
- npm test
- npm run build