### PR TITLE
Add rules kernel foundation

### DIFF
--- a/src/archive.ts
+++ b/src/archive.ts
@@ -1,26 +1,49 @@
 import { battlegroundDefinitions, cardDefinitions, pathDefinitions } from "./data";
 import {
   createGame,
+  attachItem,
   cycleCard,
   discardOversizedHands,
+  forsakeCard,
+  moveFromReserve,
   pass,
   playCard,
   resolveCombat,
   selectCard,
   selectPlayer,
+  winnow,
   usePlayerRingToken,
   validateState,
 } from "./game";
-import type { GameState, PlayerId, PlayDestination } from "./types";
+import type { ForsakeSource, GameState, PlayerId, PlayDestination } from "./types";
 
 export const archiveVersion = 1;
-export const engineVersion = "engine-command-journal-v1";
+export const engineVersion = "engine-command-journal-v2";
 export const rulesReferenceVersion = "rules-v1.1-cards-v0.2";
 export const rngVersion = "fnv1a-seed-mulberry32-v1";
 
 export type GameCommand =
+  | {
+      readonly action: "attach";
+      readonly player: PlayerId;
+      readonly item: string;
+      readonly wielder: string;
+      readonly cost?: string;
+    }
   | { readonly action: "cycle"; readonly player: PlayerId; readonly card: string }
   | { readonly action: "discardOversizedHands" }
+  | {
+      readonly action: "forsake";
+      readonly player: PlayerId;
+      readonly source: ForsakeSource;
+      readonly card?: string;
+    }
+  | {
+      readonly action: "move";
+      readonly player: PlayerId;
+      readonly card: string;
+      readonly destination: Exclude<PlayDestination, "reserve">;
+    }
   | { readonly action: "pass" }
   | {
       readonly action: "play";
@@ -167,10 +190,22 @@ export function replayArchive(archive: GameArchive): ReplayVerification {
 
 export function applyGameCommand(state: GameState, command: GameCommand): GameState {
   switch (command.action) {
+    case "attach":
+      return attachItem(
+        state,
+        command.player,
+        command.item,
+        command.wielder,
+        command.cost,
+      );
     case "cycle":
       return cycleCard(state, command.player, command.card);
     case "discardOversizedHands":
       return discardOversizedHands(state);
+    case "forsake":
+      return forsakeCard(state, command.player, command.source, command.card) ?? state;
+    case "move":
+      return moveFromReserve(state, command.player, command.card, command.destination);
     case "pass":
       return pass(state);
     case "play":

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./data";
 import {
   canPlayTo,
+  attachItem,
   createGame,
   cycleCard,
   getCard,
@@ -14,6 +15,10 @@ import {
   playCard,
   resolveCombat,
   selectPlayer,
+  tryMoveFromReserve,
+  tryPass,
+  tryWinnow,
+  tryForsake,
   usePlayerRingToken,
   validateState,
 } from "./game";
@@ -108,21 +113,24 @@ describe("game engine", () => {
     expect(validateState(next)).toEqual([]);
   });
 
-  it("allows item cards to be played to reserve but not directly to locations", () => {
+  it("attaches item cards to an indicated wielder already in play", () => {
     const playerId: PlayerId = "aragorn";
     const item = "aragorn-anduril-46-1";
     const cost = "aragorn-strider-44-1";
-    const state = setPlayerZones(createGame("reserve-item"), playerId, {
+    const wielder = "aragorn-aragorn-38-1";
+    const state = setPlayerZones(createGame("attach-item"), playerId, {
       hand: [item, cost],
+      reserve: [wielder],
     });
 
-    expect(canPlayTo(state, playerId, item, "reserve")).toBe(true);
+    expect(canPlayTo(state, playerId, item, "reserve")).toBe(false);
     expect(canPlayTo(state, playerId, item, "path")).toBe(false);
     expect(canPlayTo(state, playerId, item, "battleground")).toBe(false);
 
-    const next = playCard(state, playerId, item, "reserve", cost);
+    const next = attachItem(state, playerId, item, wielder, cost);
 
-    expect(next.players[playerId].reserve).toContain(item);
+    expect(next.attachments[wielder]).toContain(item);
+    expect(next.players[playerId].reserve).not.toContain(item);
     expect(next.players[playerId].cycle).toContain(cost);
     expect(validateState(next)).toEqual([]);
   });
@@ -213,6 +221,103 @@ describe("game engine", () => {
       const definition = getCardDefinition(card.cardId);
       expect(definition.id).toBe(card.cardId);
       expect(definition.title.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects passing above carryover when enemy hands are not larger", () => {
+    const state = {
+      ...createGame("pass-legality"),
+      activePlayer: "frodo" as const,
+    };
+
+    const result = tryPass(state);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.violation.code).toBe("pass-not-allowed");
+    }
+  });
+
+  it("moves reserve cards only after the round they entered reserve", () => {
+    const playerId: PlayerId = "frodo";
+    const card = "frodo-frodo-baggins-69-1";
+    const freshReserve = {
+      ...setPlayerZones(createGame("fresh-reserve-move"), playerId, {
+        reserve: [card],
+      }),
+      activePlayer: playerId,
+      roundMemory: { playedToReserve: [card], playedCharacterOrItemCards: [] },
+    };
+
+    const rejectedMove = tryMoveFromReserve(freshReserve, playerId, card, "path");
+
+    expect(rejectedMove.ok).toBe(false);
+    if (!rejectedMove.ok) {
+      expect(rejectedMove.violation.code).toBe("reserve-card-played-this-round");
+    }
+
+    const laterReserve = {
+      ...freshReserve,
+      roundMemory: { playedToReserve: [], playedCharacterOrItemCards: [] },
+    };
+    const moved = tryMoveFromReserve(laterReserve, playerId, card, "path");
+
+    expect(moved.ok).toBe(true);
+    if (moved.ok) {
+      expect(moved.state.activePath?.cards).toContain(card);
+      expect(moved.state.players[playerId].reserve).not.toContain(card);
+      expect(validateState(moved.state)).toEqual([]);
+    }
+  });
+
+  it("winnows by eliminating two hand cards and drawing one", () => {
+    const playerId: PlayerId = "frodo";
+    const first = "frodo-frodo-baggins-69-1";
+    const second = "frodo-sam-gamgee-72-1";
+    const drawn = "frodo-bilbo-baggins-73-1";
+    const state = {
+      ...setPlayerZones(createGame("winnow"), playerId, {
+        hand: [first, second],
+        draw: [drawn],
+        cycle: [],
+      }),
+      activePlayer: playerId,
+    };
+
+    const result = tryWinnow(state, playerId, first, second);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.state.players[playerId].eliminated).toEqual(
+        expect.arrayContaining([first, second]),
+      );
+      expect(result.state.players[playerId].hand).toContain(drawn);
+      expect(validateState(result.state)).toEqual([]);
+    }
+  });
+
+  it("forsakes a chosen hand or reserve card instead of always taking draw", () => {
+    const playerId: PlayerId = "aragorn";
+    const hand = "aragorn-boromir-39-1";
+    const reserve = "aragorn-faramir-41-1";
+    const draw = "aragorn-strider-44-1";
+    const state = setPlayerZones(createGame("forsake-choice"), playerId, {
+      hand: [hand],
+      reserve: [reserve],
+      draw: [draw],
+    });
+
+    const handResult = tryForsake(state, playerId, "hand", hand);
+    const reserveResult = tryForsake(state, playerId, "reserve", reserve);
+    const drawResult = tryForsake(state, playerId, "draw");
+
+    expect(handResult.ok).toBe(true);
+    expect(reserveResult.ok).toBe(true);
+    expect(drawResult.ok).toBe(true);
+    if (handResult.ok && reserveResult.ok && drawResult.ok) {
+      expect(handResult.state.players[playerId].eliminated).toContain(hand);
+      expect(reserveResult.state.players[playerId].eliminated).toContain(reserve);
+      expect(drawResult.state.players[playerId].eliminated).toContain(draw);
     }
   });
 });

--- a/src/game.ts
+++ b/src/game.ts
@@ -10,18 +10,22 @@ import type {
   ActivePath,
   CardDefinition,
   CardInstance,
+  CommandResult,
+  ForsakeSource,
   Faction,
   GameState,
   Phase,
   PlayDestination,
   PlayerId,
   PlayerState,
+  RuleViolation,
   Side,
 } from "./types";
 
 const startingHandSize = 7;
 const setupCycleCount = 2;
 const handLimit = 6;
+const baseCarryoverLimit = 2;
 
 const cardById: ReadonlyMap<string, CardDefinition> = new Map(
   cardDefinitions.map((card) => [card.id, card]),
@@ -114,6 +118,8 @@ export function createGame(seed = String(Date.now())): GameState {
     activePath: null,
     players: playerStates,
     cards: instances,
+    attachments: {},
+    roundMemory: { playedToReserve: [], playedCharacterOrItemCards: [] },
     score: { free: 0, shadow: 0 },
     log: [],
     selection: { playerId: "frodo", cardId: null },
@@ -150,6 +156,39 @@ export function playSelected(
   return playCard(state, playerId, instanceId, destination);
 }
 
+export function tryPlayCard(
+  state: GameState,
+  playerId: PlayerId,
+  instanceId: string,
+  destination: PlayDestination,
+  costCardId?: string,
+): CommandResult {
+  const turnViolation = validateActionTurn(state, playerId);
+  if (turnViolation !== null) {
+    return rejected(state, turnViolation);
+  }
+  if (!canPlayTo(state, playerId, instanceId, destination)) {
+    return rejected(state, {
+      code: "invalid-destination",
+      message: "That card cannot be played there.",
+      source: "rules:151-199",
+    });
+  }
+  const cardDef = getCardDefinition(getCard(state, instanceId).cardId);
+  if (
+    (cardDef.type === "character" || cardDef.type === "item") &&
+    state.roundMemory.playedCharacterOrItemCards.includes(cardDef.id)
+  ) {
+    return rejected(state, {
+      code: "repeat-character-or-item-this-round",
+      message: "The exact same character or item card cannot be played twice in one round.",
+      source: "rules:217",
+    });
+  }
+  const nextState = playCard(state, playerId, instanceId, destination, costCardId);
+  return accepted(nextState, [`played:${instanceId}:${destination}`]);
+}
+
 export function playCard(
   state: GameState,
   playerId: PlayerId,
@@ -175,10 +214,16 @@ export function playCard(
   };
 
   if (destination === "reserve") {
-    nextState = updatePlayer(nextState, playerId, (current) => ({
-      ...current,
-      reserve: [...current.reserve, instanceId],
-    }));
+    nextState = {
+      ...updatePlayer(nextState, playerId, (current) => ({
+        ...current,
+        reserve: [...current.reserve, instanceId],
+      })),
+      roundMemory: {
+        ...nextState.roundMemory,
+        playedToReserve: [...nextState.roundMemory.playedToReserve, instanceId],
+      },
+    };
   } else if (destination === "battleground") {
     nextState = {
       ...nextState,
@@ -216,9 +261,107 @@ export function playCard(
     nextState = forsakeFromTopOfDeck(nextState, playerId);
   }
 
+  if (cardDef.type === "character" || cardDef.type === "item") {
+    nextState = rememberCharacterOrItemPlayed(nextState, cardDef.id);
+  }
+
   return addLog(
     nextState,
     `${players[playerId].name} played ${cardDef.title} to ${destination}.`,
+  );
+}
+
+export function tryAttachItem(
+  state: GameState,
+  playerId: PlayerId,
+  itemId: string,
+  wielderId: string,
+  costCardId?: string,
+): CommandResult {
+  const turnViolation = validateActionTurn(state, playerId);
+  if (turnViolation !== null) {
+    return rejected(state, turnViolation);
+  }
+
+  const player = state.players[playerId];
+  if (!player.hand.includes(itemId)) {
+    return rejected(state, {
+      code: "card-not-in-hand",
+      message: "Only an item in hand can be attached.",
+      source: "rules:173-177",
+    });
+  }
+  const itemDef = getCardDefinition(getCard(state, itemId).cardId);
+  if (itemDef.type !== "item") {
+    return rejected(state, {
+      code: "invalid-wielder",
+      message: "Only item cards can be attached to a wielder.",
+      source: "rules:173",
+    });
+  }
+  if (state.roundMemory.playedCharacterOrItemCards.includes(itemDef.id)) {
+    return rejected(state, {
+      code: "repeat-character-or-item-this-round",
+      message: "The exact same character or item card cannot be played twice in one round.",
+      source: "rules:217",
+    });
+  }
+  if (!isValidWielder(state, itemDef, wielderId)) {
+    return rejected(state, {
+      code: "invalid-wielder",
+      message: "An item can only be played on an indicated character already in play.",
+      source: "rules:173-177",
+    });
+  }
+  if (Object.values(state.attachments).some((items) => items.includes(itemId))) {
+    return rejected(state, {
+      code: "item-already-attached",
+      message: "That item is already attached.",
+      source: "rules:187",
+    });
+  }
+
+  const nextState = attachItem(state, playerId, itemId, wielderId, costCardId);
+  return accepted(nextState, [`attached:${itemId}:${wielderId}`]);
+}
+
+export function attachItem(
+  state: GameState,
+  playerId: PlayerId,
+  itemId: string,
+  wielderId: string,
+  costCardId?: string,
+): GameState {
+  const player = state.players[playerId];
+  const nextHand = removeOne(player.hand, itemId);
+  const requiredCycle = costCardId ?? nextHand[0] ?? null;
+  let nextState: GameState = {
+    ...state,
+    players: setPlayer(state.players, playerId, { ...player, hand: nextHand }),
+    attachments: {
+      ...state.attachments,
+      [wielderId]: [...(state.attachments[wielderId] ?? []), itemId],
+    },
+    selection: { ...state.selection, cardId: nextHand[0] ?? null },
+  };
+
+  if (requiredCycle !== null) {
+    if (requiredCycle === itemId || !nextHand.includes(requiredCycle)) {
+      return addLog(state, "Playing an item requires cycling a different hand card.");
+    }
+    nextState = updatePlayer(nextState, playerId, (current) => ({
+      ...current,
+      hand: removeOne(current.hand, requiredCycle),
+      cycle: [...current.cycle, requiredCycle],
+    }));
+  } else {
+    nextState = forsakeFromTopOfDeck(nextState, playerId);
+  }
+
+  const itemDef = getCardDefinition(getCard(state, itemId).cardId);
+  return addLog(
+    rememberCharacterOrItemPlayed(nextState, itemDef.id),
+    `${players[playerId].name} attached ${itemDef.title}.`,
   );
 }
 
@@ -280,8 +423,27 @@ export function usePlayerRingToken(
   );
 }
 
+export function tryPass(state: GameState): CommandResult {
+  const playerId = state.activePlayer;
+  const turnViolation = validateActionTurn(state, playerId);
+  if (turnViolation !== null) {
+    return rejected(state, turnViolation);
+  }
+  if (!canPass(state, playerId)) {
+    return rejected(state, {
+      code: "pass-not-allowed",
+      message: "A player can pass only under carryover or enemy-hand conditions.",
+      source: "rules:142-145",
+    });
+  }
+  return accepted(pass(state), [`passed:${playerId}`]);
+}
+
 export function pass(state: GameState): GameState {
   const playerId = state.activePlayer;
+  if (!canPass(state, playerId)) {
+    return addLog(state, `${players[playerId].name} cannot pass yet.`);
+  }
   const nextState = updatePlayer(state, playerId, (player) => ({
     ...player,
     passed: true,
@@ -296,6 +458,175 @@ export function pass(state: GameState): GameState {
     { ...nextState, activePlayer: nextPlayerId(playerId) },
     `${players[playerId].name} passed.`,
   );
+}
+
+export function canPass(state: GameState, playerId: PlayerId): boolean {
+  const player = state.players[playerId];
+  if (player.hand.length <= carryoverLimit(state, playerId)) {
+    return true;
+  }
+  return enemyPlayers(playerId).every(
+    (enemyId) => player.hand.length < state.players[enemyId].hand.length,
+  );
+}
+
+export function tryMoveFromReserve(
+  state: GameState,
+  playerId: PlayerId,
+  instanceId: string,
+  destination: Exclude<PlayDestination, "reserve">,
+): CommandResult {
+  const turnViolation = validateActionTurn(state, playerId);
+  if (turnViolation !== null) {
+    return rejected(state, turnViolation);
+  }
+  const player = state.players[playerId];
+  if (!player.reserve.includes(instanceId)) {
+    return rejected(state, {
+      code: "card-not-in-reserve",
+      message: "Only a card in reserve can be moved.",
+      source: "rules:222-227",
+    });
+  }
+  if (state.roundMemory.playedToReserve.includes(instanceId)) {
+    return rejected(state, {
+      code: "reserve-card-played-this-round",
+      message: "Cards played to reserve cannot be moved in the same round.",
+      source: "rules:200-206",
+    });
+  }
+  if (!canMoveTo(state, playerId, instanceId, destination)) {
+    return rejected(state, {
+      code: "invalid-destination",
+      message: "That reserve card cannot be moved there.",
+      source: "rules:222-227",
+    });
+  }
+  return accepted(moveFromReserve(state, playerId, instanceId, destination), [
+    `moved:${instanceId}:${destination}`,
+  ]);
+}
+
+export function moveFromReserve(
+  state: GameState,
+  playerId: PlayerId,
+  instanceId: string,
+  destination: Exclude<PlayDestination, "reserve">,
+): GameState {
+  const cardDef = getCardDefinition(getCard(state, instanceId).cardId);
+  let nextState = updatePlayer(state, playerId, (player) => ({
+    ...player,
+    reserve: removeOne(player.reserve, instanceId),
+  }));
+
+  if (destination === "battleground") {
+    nextState = {
+      ...nextState,
+      activeBattleground:
+        nextState.activeBattleground === null
+          ? null
+          : {
+              ...nextState.activeBattleground,
+              cards: [...nextState.activeBattleground.cards, instanceId],
+            },
+    };
+  } else {
+    nextState = {
+      ...nextState,
+      activePath:
+        nextState.activePath === null
+          ? null
+          : {
+              ...nextState.activePath,
+              cards: [...nextState.activePath.cards, instanceId],
+            },
+    };
+  }
+
+  return addLog(
+    nextState,
+    `${players[playerId].name} moved ${cardDef.title} to ${destination}.`,
+  );
+}
+
+export function tryWinnow(
+  state: GameState,
+  playerId: PlayerId,
+  firstCardId: string,
+  secondCardId: string,
+): CommandResult {
+  const turnViolation = validateActionTurn(state, playerId);
+  if (turnViolation !== null) {
+    return rejected(state, turnViolation);
+  }
+  const player = state.players[playerId];
+  if (
+    firstCardId === secondCardId ||
+    !player.hand.includes(firstCardId) ||
+    !player.hand.includes(secondCardId)
+  ) {
+    return rejected(state, {
+      code: "insufficient-hand-cards",
+      message: "Winnow requires eliminating two different cards from hand.",
+      source: "rules:138,242",
+    });
+  }
+  return accepted(winnow(state, playerId, firstCardId, secondCardId), [
+    `winnowed:${firstCardId}:${secondCardId}`,
+  ]);
+}
+
+export function winnow(
+  state: GameState,
+  playerId: PlayerId,
+  firstCardId: string,
+  secondCardId: string,
+): GameState {
+  const nextState = drawCards(
+    eliminateCards(state, [firstCardId, secondCardId]),
+    playerId,
+    1,
+  );
+  return addLog(nextState, `${players[playerId].name} winnowed 2 cards.`);
+}
+
+export function tryForsake(
+  state: GameState,
+  playerId: PlayerId,
+  source: ForsakeSource,
+  instanceId?: string,
+): CommandResult {
+  const nextState = forsakeCard(state, playerId, source, instanceId);
+  if (nextState === null) {
+    return rejected(state, {
+      code: "invalid-forsake-source",
+      message: "Forsake must choose a card from hand, reserve, or the top of the draw deck.",
+      source: "rules:385-395",
+    });
+  }
+  return accepted(nextState, [`forsook:${source}:${instanceId ?? "top"}`]);
+}
+
+export function forsakeCard(
+  state: GameState,
+  playerId: PlayerId,
+  source: ForsakeSource,
+  instanceId?: string,
+): GameState | null {
+  const player = state.players[playerId];
+  if (source === "draw") {
+    return forsakeFromTopOfDeck(state, playerId);
+  }
+  if (instanceId === undefined) {
+    return null;
+  }
+  if (source === "hand" && player.hand.includes(instanceId)) {
+    return eliminateCards(state, [instanceId]);
+  }
+  if (source === "reserve" && player.reserve.includes(instanceId)) {
+    return eliminateCards(state, [instanceId]);
+  }
+  return null;
 }
 
 export function nextTurn(state: GameState): GameState {
@@ -369,6 +700,7 @@ export function validateState(state: GameState): readonly string[] {
     }),
     state.activeBattleground?.cards ?? [],
     state.activePath?.cards ?? [],
+    ...Object.values(state.attachments),
   ];
 
   for (const zone of allZones) {
@@ -403,6 +735,35 @@ export function validateState(state: GameState): readonly string[] {
     }
   }
 
+  for (const [wielderId, itemIds] of Object.entries(state.attachments)) {
+    const wielder = state.cards[wielderId];
+    if (wielder === undefined) {
+      errors.push(`Attachment references unknown wielder: ${wielderId}`);
+      continue;
+    }
+    const wielderDef = getCardDefinition(wielder.cardId);
+    if (wielderDef.type !== "character") {
+      errors.push(`Attachment wielder is not a character: ${wielderId}`);
+    }
+    if (!isInPlay(state, wielderId)) {
+      errors.push(`Attachment wielder is not in play: ${wielderId}`);
+    }
+    for (const itemId of itemIds) {
+      const item = state.cards[itemId];
+      if (item === undefined) {
+        errors.push(`Attachment references unknown item: ${itemId}`);
+        continue;
+      }
+      const itemDef = getCardDefinition(item.cardId);
+      if (itemDef.type !== "item") {
+        errors.push(`Attached card is not an item: ${itemId}`);
+      }
+      if (!isAllowedWielderName(itemDef, wielderDef.title)) {
+        errors.push(`Item ${itemId} cannot be attached to ${wielderId}`);
+      }
+    }
+  }
+
   return errors;
 }
 
@@ -419,7 +780,7 @@ export function canPlayTo(
   const card = getCard(state, instanceId);
   const cardDef = getCardDefinition(card.cardId);
   if (destination === "reserve") {
-    return cardDef.type === "army" || cardDef.type === "character" || cardDef.type === "item";
+    return cardDef.type === "army" || cardDef.type === "character";
   }
   if (destination === "battleground") {
     const battleground = state.activeBattleground;
@@ -442,6 +803,44 @@ export function canPlayTo(
     cardDef.type === "character" &&
     cardDef.allowedPaths.includes(pathById.get(path.id)?.pathNumber ?? -1)
   );
+}
+
+export function canMoveTo(
+  state: GameState,
+  playerId: PlayerId,
+  instanceId: string,
+  destination: Exclude<PlayDestination, "reserve">,
+): boolean {
+  const player = state.players[playerId];
+  if (!player.reserve.includes(instanceId)) {
+    return false;
+  }
+  const card = getCard(state, instanceId);
+  const cardDef = getCardDefinition(card.cardId);
+  if (cardDef.type !== "army" && cardDef.type !== "character") {
+    return false;
+  }
+  if (destination === "path") {
+    const path = state.activePath;
+    return (
+      path !== null &&
+      cardDef.type === "character" &&
+      cardDef.allowedPaths.includes(pathById.get(path.id)?.pathNumber ?? -1)
+    );
+  }
+  const battleground = state.activeBattleground;
+  if (battleground === null) {
+    return false;
+  }
+  const battlegroundDef = battlegroundById.get(battleground.id);
+  if (battlegroundDef === undefined) {
+    return false;
+  }
+  const playableFactions: readonly Faction[] = [
+    ...battlegroundDef.attackingFactions,
+    ...battlegroundDef.defendingFactions,
+  ];
+  return playableFactions.includes(cardDef.faction);
 }
 
 function startRound(state: GameState): GameState {
@@ -486,6 +885,7 @@ function startRound(state: GameState): GameState {
       pathDeck: nextPathDeck,
       activeBattleground: nextBattleground,
       activePath: nextPath,
+      roundMemory: { playedToReserve: [], playedCharacterOrItemCards: [] },
     },
     `Round ${state.round}: activated ${labelBattleground(nextBattleground)} and ${labelPath(
       nextPath,
@@ -634,33 +1034,207 @@ function forsakeFromTopOfDeck(state: GameState, playerId: PlayerId): GameState {
 }
 
 function eliminateCards(state: GameState, instanceIds: readonly string[]): GameState {
-  return instanceIds.reduce((nextState, instanceId) => {
+  const cardsToEliminate = expandWithAttachedItems(state, instanceIds);
+  return cardsToEliminate.reduce((nextState, instanceId) => {
     const owner = findOwner(nextState, instanceId);
     if (owner === null) {
       return nextState;
     }
-    return updatePlayer(nextState, owner, (player) => ({
-      ...player,
-      reserve: removeOne(player.reserve, instanceId),
-      hand: removeOne(player.hand, instanceId),
-      eliminated: [...player.eliminated, instanceId],
-    }));
-  }, state);
+    return stripEmptyAttachmentLists(
+      removeFromSharedPlayZones(
+        updatePlayer(nextState, owner, (player) => ({
+          ...player,
+          reserve: removeOne(player.reserve, instanceId),
+          hand: removeOne(player.hand, instanceId),
+          draw: removeOne(player.draw, instanceId),
+          cycle: removeOne(player.cycle, instanceId),
+          eliminated: player.eliminated.includes(instanceId)
+            ? player.eliminated
+            : [...player.eliminated, instanceId],
+        })),
+        instanceId,
+      ),
+    );
+  }, removeAttachmentLinks(state, cardsToEliminate));
 }
 
 function cycleCards(state: GameState, instanceIds: readonly string[]): GameState {
-  return instanceIds.reduce((nextState, instanceId) => {
+  const cardsToCycle = expandWithAttachedItems(state, instanceIds);
+  return cardsToCycle.reduce((nextState, instanceId) => {
     const owner = findOwner(nextState, instanceId);
     if (owner === null) {
       return nextState;
     }
-    return updatePlayer(nextState, owner, (player) => ({
-      ...player,
-      reserve: removeOne(player.reserve, instanceId),
-      hand: removeOne(player.hand, instanceId),
-      cycle: [...player.cycle, instanceId],
-    }));
-  }, state);
+    return stripEmptyAttachmentLists(
+      removeFromSharedPlayZones(
+        updatePlayer(nextState, owner, (player) => ({
+          ...player,
+          reserve: removeOne(player.reserve, instanceId),
+          hand: removeOne(player.hand, instanceId),
+          draw: removeOne(player.draw, instanceId),
+          eliminated: removeOne(player.eliminated, instanceId),
+          cycle: player.cycle.includes(instanceId) ? player.cycle : [...player.cycle, instanceId],
+        })),
+        instanceId,
+      ),
+    );
+  }, removeAttachmentLinks(state, cardsToCycle));
+}
+
+function expandWithAttachedItems(
+  state: GameState,
+  instanceIds: readonly string[],
+): readonly string[] {
+  const expanded: string[] = [];
+  const visit = (instanceId: string): void => {
+    if (expanded.includes(instanceId)) {
+      return;
+    }
+    expanded.push(instanceId);
+    for (const itemId of state.attachments[instanceId] ?? []) {
+      visit(itemId);
+    }
+  };
+  for (const instanceId of instanceIds) {
+    visit(instanceId);
+  }
+  return expanded;
+}
+
+function removeAttachmentLinks(
+  state: GameState,
+  instanceIds: readonly string[],
+): GameState {
+  const removing = new Set(instanceIds);
+  return {
+    ...state,
+    attachments: Object.fromEntries(
+      Object.entries(state.attachments)
+        .filter(([wielderId]) => !removing.has(wielderId))
+        .map(([wielderId, itemIds]) => [
+          wielderId,
+          itemIds.filter((itemId) => !removing.has(itemId)),
+        ]),
+    ),
+  };
+}
+
+function stripEmptyAttachmentLists(state: GameState): GameState {
+  return {
+    ...state,
+    attachments: Object.fromEntries(
+      Object.entries(state.attachments).filter(([, itemIds]) => itemIds.length > 0),
+    ),
+  };
+}
+
+function removeFromSharedPlayZones(state: GameState, instanceId: string): GameState {
+  return {
+    ...state,
+    activeBattleground:
+      state.activeBattleground === null
+        ? null
+        : {
+            ...state.activeBattleground,
+            cards: removeOne(state.activeBattleground.cards, instanceId),
+          },
+    activePath:
+      state.activePath === null
+        ? null
+        : {
+            ...state.activePath,
+            cards: removeOne(state.activePath.cards, instanceId),
+          },
+  };
+}
+
+function rememberCharacterOrItemPlayed(state: GameState, cardId: string): GameState {
+  if (state.roundMemory.playedCharacterOrItemCards.includes(cardId)) {
+    return state;
+  }
+  return {
+    ...state,
+    roundMemory: {
+      ...state.roundMemory,
+      playedCharacterOrItemCards: [
+        ...state.roundMemory.playedCharacterOrItemCards,
+        cardId,
+      ],
+    },
+  };
+}
+
+function isValidWielder(
+  state: GameState,
+  itemDef: CardDefinition,
+  wielderId: string,
+): boolean {
+  if (!isInPlay(state, wielderId)) {
+    return false;
+  }
+  const wielder = state.cards[wielderId];
+  if (wielder === undefined) {
+    return false;
+  }
+  const wielderDef = getCardDefinition(wielder.cardId);
+  return wielderDef.type === "character" && isAllowedWielderName(itemDef, wielderDef.title);
+}
+
+function isAllowedWielderName(itemDef: CardDefinition, wielderTitle: string): boolean {
+  return itemDef.allowedWielders.some((allowed) => {
+    const normalizedAllowed = normalizeName(allowed);
+    const normalizedTitle = normalizeName(wielderTitle);
+    return (
+      normalizedAllowed === normalizedTitle ||
+      normalizedTitle.includes(normalizedAllowed) ||
+      normalizedAllowed.includes(normalizedTitle)
+    );
+  });
+}
+
+function isInPlay(state: GameState, instanceId: string): boolean {
+  return (
+    Object.values(state.players).some((player) => player.reserve.includes(instanceId)) ||
+    (state.activeBattleground?.cards.includes(instanceId) ?? false) ||
+    (state.activePath?.cards.includes(instanceId) ?? false)
+  );
+}
+
+function carryoverLimit(_state: GameState, _playerId: PlayerId): number {
+  return baseCarryoverLimit;
+}
+
+function enemyPlayers(playerId: PlayerId): readonly PlayerId[] {
+  const side = players[playerId].side;
+  return turnOrder.filter((candidate) => players[candidate].side !== side);
+}
+
+function validateActionTurn(state: GameState, playerId: PlayerId): RuleViolation | null {
+  if (state.phase !== "action") {
+    return {
+      code: "wrong-phase",
+      message: "This command can only be used during the action phase.",
+    };
+  }
+  if (state.activePlayer !== playerId) {
+    return {
+      code: "wrong-player",
+      message: "Only the active player can take an action.",
+    };
+  }
+  return null;
+}
+
+function accepted(state: GameState, events: readonly string[]): CommandResult {
+  return { ok: true, state, events };
+}
+
+function rejected(state: GameState, violation: RuleViolation): CommandResult {
+  return { ok: false, state, violation };
+}
+
+function normalizeName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
 }
 
 function assignDefenderLosses(

--- a/src/gameScripts.test.ts
+++ b/src/gameScripts.test.ts
@@ -36,11 +36,11 @@ const legalityCases = cardDefinitions.flatMap((card) =>
 );
 
 const reservePlayCases = cardDefinitions
-  .filter((card) => card.type !== "event")
+  .filter((card) => card.type === "army" || card.type === "character")
   .map((card) => ({ name: `${card.owner}:${card.id}:reserve-play`, card }));
 
 const lastCardCases = cardDefinitions
-  .filter((card) => card.type !== "event")
+  .filter((card) => card.type === "army" || card.type === "character")
   .map((card) => ({ name: `${card.owner}:${card.id}:last-card`, card }));
 
 const generatedCaseCount =
@@ -63,19 +63,19 @@ describe("compact game scripts", () => {
       arrange: {
         players: {
           aragorn: {
-            hand: ["anduril-46", "strider-44"],
+            hand: ["strider-44", "aragorn-38"],
           },
         },
       },
       steps: [
         { action: "selectPlayer", player: "aragorn" },
-        { action: "play", player: "aragorn", card: "anduril-46", destination: "reserve" },
+        { action: "play", player: "aragorn", card: "strider-44", destination: "reserve" },
       ],
     });
 
     expect(result.frames).toHaveLength(3);
     expect(result.frames.every((frame) => frame.errors.length === 0)).toBe(true);
-    expect(renderReplay(result)).toContain("aragorn play anduril-46 to reserve");
+    expect(renderReplay(result)).toContain("aragorn play strider-44 to reserve");
     expect(exportGameScript(result.script)).toContain('"seed": "example-replay"');
   });
 
@@ -241,7 +241,7 @@ function expectedLegality(
   destination: PlayDestination,
 ): boolean {
   if (destination === "reserve") {
-    return card.type !== "event";
+    return card.type === "army" || card.type === "character";
   }
   if (destination === "path") {
     const path = pathDefinitions.find((candidate) => candidate.id === state.activePath?.id);

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -15,7 +15,7 @@ export function loadGame(): GameState | null {
   try {
     const parsed: unknown = JSON.parse(raw);
     if (isGameState(parsed)) {
-      return parsed;
+      return normalizeGameState(parsed);
     }
   } catch {
     return null;
@@ -37,4 +37,15 @@ function isGameState(value: unknown): value is GameState {
     "players" in value &&
     "cards" in value
   );
+}
+
+function normalizeGameState(state: GameState): GameState {
+  return {
+    ...state,
+    attachments: state.attachments ?? {},
+    roundMemory: state.roundMemory ?? {
+      playedToReserve: [],
+      playedCharacterOrItemCards: [],
+    },
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,8 @@ export type Phase = "setup" | "action" | "combat" | "gameOver";
 
 export type PlayDestination = "reserve" | "battleground" | "path";
 
+export type ForsakeSource = "hand" | "reserve" | "draw";
+
 export interface CardDefinition {
   readonly id: string;
   readonly title: string;
@@ -119,6 +121,13 @@ export interface SelectionState {
   readonly cardId: string | null;
 }
 
+export interface RoundMemory {
+  readonly playedToReserve: readonly string[];
+  readonly playedCharacterOrItemCards: readonly string[];
+}
+
+export type AttachmentState = Readonly<Record<string, readonly string[]>>;
+
 export interface GameState {
   readonly schemaVersion: 1;
   readonly seed: string;
@@ -132,10 +141,38 @@ export interface GameState {
   readonly activePath: ActivePath | null;
   readonly players: Readonly<Record<PlayerId, PlayerState>>;
   readonly cards: Readonly<Record<string, CardInstance>>;
+  readonly attachments: AttachmentState;
+  readonly roundMemory: RoundMemory;
   readonly score: ScoreState;
   readonly log: readonly LogEntry[];
   readonly selection: SelectionState;
 }
+
+export type RuleViolationCode =
+  | "wrong-phase"
+  | "wrong-player"
+  | "card-not-found"
+  | "card-not-in-hand"
+  | "card-not-in-reserve"
+  | "invalid-destination"
+  | "invalid-cost"
+  | "invalid-forsake-source"
+  | "invalid-wielder"
+  | "item-already-attached"
+  | "reserve-card-played-this-round"
+  | "repeat-character-or-item-this-round"
+  | "pass-not-allowed"
+  | "insufficient-hand-cards";
+
+export interface RuleViolation {
+  readonly code: RuleViolationCode;
+  readonly message: string;
+  readonly source?: string;
+}
+
+export type CommandResult =
+  | { readonly ok: true; readonly state: GameState; readonly events: readonly string[] }
+  | { readonly ok: false; readonly state: GameState; readonly violation: RuleViolation };
 
 export interface GameViewModel {
   readonly state: GameState;


### PR DESCRIPTION
## Summary
- add typed rule results and violations for action commands
- model item attachments and round-local memory in serialized game state
- implement generic rules for item attachment, reserve movement timing, pass legality, winnow, and explicit forsake choices
- update archive command vocabulary and bump engine journal tag for state-shape drift
- migrate old local saved games by defaulting new state fields
- correct generated tests so items are attached to wielders instead of played to reserve

## Verification
- npm test
- npm run typecheck
- npm run build

## Notes
This is the foundation slice for the larger rules rewrite. Card-specific text, location activation queues, scoring areas, visibility, and combat decision prompts still need dedicated follow-up slices.
