### PR TITLE
Reapply standalone table UI on rules kernel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: ["master"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Unit tests
+        run: npm test
+      - name: Build
+        run: npm run build
+      - name: End-to-end UI tests
+        run: npm run test:e2e

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,10 +27,14 @@ jobs:
           cache: npm
       - name: Install
         run: npm ci
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
       - name: Test
         run: npm test
       - name: Build
         run: npm run build
+      - name: End-to-end UI tests
+        run: npm run test:e2e
       - name: Configure Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,8 @@ cython_debug/
 node_modules/
 dist/
 coverage/
+playwright-report/
+test-results/
 
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "vite": "^7.1.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "jsdom": "^29.1.1",
         "typescript": "^5.9.0",
         "vitest": "^4.1.9"
@@ -660,6 +661,22 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
@@ -1509,6 +1526,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "vite": "^7.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "jsdom": "^29.1.1",
     "typescript": "^5.9.0",
     "vitest": "^4.1.9"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env["CI"]),
+  retries: process.env["CI"] ? 2 : 0,
+  reporter: process.env["CI"] ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173/wotr-card-game-python/",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "npm run build && npm run preview -- --host 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173/wotr-card-game-python/",
+    reuseExistingServer: !process.env["CI"],
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,63 +1,349 @@
 import "./styles.css";
-import {
-  createGame,
-  cycleSelected,
-  discardOversizedHands,
-  nextTurn,
-  pass,
-  playSelected,
-  resolveCombat,
-  selectCard,
-  selectPlayer,
-  useRingToken,
-} from "./game";
-import { render } from "./render";
-import { clearSavedGame, loadGame, saveGame } from "./storage";
-import type { GameState, PlayDestination, PlayerId } from "./types";
+
+type Seat = "north" | "east" | "south" | "west";
+type Side = "free" | "shadow";
+type CardKind = "army" | "character" | "event" | "item";
+type CardZone = "hand" | "reserve" | "battle" | "path";
+
+interface PlayerMock {
+  readonly id: string;
+  readonly name: string;
+  readonly seat: Seat;
+  readonly side: Side;
+  readonly handCount: number;
+  readonly deckCount: number;
+  readonly cycleCount: number;
+  readonly eliminatedCount: number;
+}
+
+interface CardMock {
+  readonly id: string;
+  readonly ownerId: string;
+  readonly title: string;
+  readonly faction: string;
+  readonly kind: CardKind;
+  readonly zone: CardZone;
+  readonly art: string;
+  readonly strength: string;
+  readonly text: string;
+}
+
+interface LogEntry {
+  readonly id: number;
+  readonly text: string;
+}
+
+interface UiState {
+  activePlayerId: string;
+  selectedCardId: string;
+  combatPulse: number;
+  log: readonly LogEntry[];
+}
+
+const players: readonly PlayerMock[] = [
+  {
+    id: "frodo",
+    name: "Frodo",
+    seat: "south",
+    side: "free",
+    handCount: 6,
+    deckCount: 18,
+    cycleCount: 4,
+    eliminatedCount: 1,
+  },
+  {
+    id: "witchKing",
+    name: "Witch-king",
+    seat: "west",
+    side: "shadow",
+    handCount: 5,
+    deckCount: 21,
+    cycleCount: 3,
+    eliminatedCount: 2,
+  },
+  {
+    id: "aragorn",
+    name: "Aragorn",
+    seat: "north",
+    side: "free",
+    handCount: 5,
+    deckCount: 16,
+    cycleCount: 6,
+    eliminatedCount: 0,
+  },
+  {
+    id: "saruman",
+    name: "Saruman",
+    seat: "east",
+    side: "shadow",
+    handCount: 7,
+    deckCount: 23,
+    cycleCount: 2,
+    eliminatedCount: 1,
+  },
+];
+
+const cards: readonly CardMock[] = [
+  {
+    id: "sting",
+    ownerId: "frodo",
+    title: "Sting",
+    faction: "Hobbit",
+    kind: "item",
+    zone: "hand",
+    art: "blade",
+    strength: "+1",
+    text: "If the wielder is on a path with a Monstrous Character then add 1 Defense token to the active path.",
+  },
+  {
+    id: "samwise",
+    ownerId: "frodo",
+    title: "Samwise the Brave",
+    faction: "Hobbit",
+    kind: "character",
+    zone: "hand",
+    art: "shire",
+    strength: "2",
+    text: "If eliminated in path combat, cycle instead along with any wielded items.",
+  },
+  {
+    id: "mithril",
+    ownerId: "frodo",
+    title: "Mithril Coat",
+    faction: "Dwarf",
+    kind: "item",
+    zone: "hand",
+    art: "mail",
+    strength: "+2",
+    text: "No rules text. Adds 2 path icons while wielded by Frodo or Sam.",
+  },
+  {
+    id: "gandalf",
+    ownerId: "frodo",
+    title: "Gandalf the White",
+    faction: "Wizard",
+    kind: "character",
+    zone: "reserve",
+    art: "wizard",
+    strength: "3",
+    text: "When played remove GtG from the game; while in reserve draw +1 card in each Draw step. If forsaken from top of the draw deck, cycle instead.",
+  },
+  {
+    id: "anduril",
+    ownerId: "aragorn",
+    title: "Anduril",
+    faction: "Dunedain",
+    kind: "item",
+    zone: "hand",
+    art: "sword",
+    strength: "+3",
+    text: "No rules text. Item wielded by Strider or Aragorn with 1 attack icon, 1 defense icon, and 1 path icon.",
+  },
+  {
+    id: "legolas",
+    ownerId: "aragorn",
+    title: "Legolas",
+    faction: "Elf",
+    kind: "character",
+    zone: "hand",
+    art: "forest",
+    strength: "3",
+    text: "When played you may take the Bow of Galadhrim from your draw deck into hand.",
+  },
+  {
+    id: "elrond",
+    ownerId: "aragorn",
+    title: "Elrond",
+    faction: "Elf",
+    kind: "character",
+    zone: "reserve",
+    art: "council",
+    strength: "3",
+    text: "When played draw 1 card. While in reserve increase your carryover limit by 1.",
+  },
+  {
+    id: "mordor-host",
+    ownerId: "witchKing",
+    title: "Mordor Orcs",
+    faction: "Mordor",
+    kind: "army",
+    zone: "hand",
+    art: "mordor",
+    strength: "4",
+    text: "No rules text. Mordor army card with 1 attack icon and 1 defense icon.",
+  },
+  {
+    id: "black-captain",
+    ownerId: "witchKing",
+    title: "The Black Captain",
+    faction: "Mordor",
+    kind: "event",
+    zone: "hand",
+    art: "wraith",
+    strength: "3",
+    text: "If the Witch-King is in reserve (active or not), (re)activate any Mordor battleground, then you MAY move the Witch-King to this battleground.",
+  },
+  {
+    id: "fell-beast",
+    ownerId: "witchKing",
+    title: "Fell Beast",
+    faction: "Mordor",
+    kind: "item",
+    zone: "battle",
+    art: "beast",
+    strength: "2",
+    text: "When played on a Nazgul in reserve (active or not), you may immediately move them to a battleground.",
+  },
+  {
+    id: "orthanc",
+    ownerId: "saruman",
+    title: "Palantir",
+    faction: "Isengard",
+    kind: "event",
+    zone: "hand",
+    art: "tower",
+    strength: "E",
+    text: "If Saruman is in reserve (active or not), (re)activate any Isengard battleground of your choice, then you MAY move Saruman to that battleground.",
+  },
+  {
+    id: "uruk-hai",
+    ownerId: "saruman",
+    title: "Fighting Uruk-Hai",
+    faction: "Isengard",
+    kind: "army",
+    zone: "hand",
+    art: "uruk",
+    strength: "3",
+    text: "No rules text. Isengard army with battleground attack and defense icons.",
+  },
+  {
+    id: "southron",
+    ownerId: "saruman",
+    title: "The Black Serpent",
+    faction: "Southron",
+    kind: "character",
+    zone: "path",
+    art: "desert",
+    strength: "E",
+    text: "If in reserve you may use your action and eliminate this card to reactivate any Southron battleground.",
+  },
+  {
+    id: "gimli",
+    ownerId: "frodo",
+    title: "Gimli",
+    faction: "Dwarf",
+    kind: "character",
+    zone: "battle",
+    art: "axe",
+    strength: "3",
+    text: "When played you may take \"Dwarevn Axe\" from your cycle pile into your hand.",
+  },
+  {
+    id: "gollum",
+    ownerId: "saruman",
+    title: "Gollum",
+    faction: "Monstrous",
+    kind: "character",
+    zone: "path",
+    art: "cavern",
+    strength: "E",
+    text: "If on a path you may use your action to activate a different path of the same #. If Gollum is eliminated in path combat, cycle instead.",
+  },
+];
+
+let state: UiState = {
+  activePlayerId: "frodo",
+  selectedCardId: "sting",
+  combatPulse: 0,
+  log: [
+    { id: 5, text: "Fell Beast committed to Minas Tirith." },
+    { id: 4, text: "Gimli answered the battleground call." },
+    { id: 3, text: "Southron Ambush moved onto the path." },
+    { id: 2, text: "Frodo held Mithril Coat in reserve range." },
+    { id: 1, text: "Round 3 action phase began from seed table-demo." },
+  ],
+};
 
 const root = document.querySelector<HTMLDivElement>("#app");
 if (root === null) {
   throw new Error("Missing #app root");
 }
 const appRoot = root;
+let zoomTimer: number | null = null;
+let zoomPreview: HTMLElement | null = null;
 
-let state = loadGame() ?? createGame("middle-earth");
-
-function commit(nextState: GameState, shouldSave = true): void {
-  state = discardOversizedHands(nextState);
-  if (shouldSave) {
-    saveGame(state);
-  }
-  appRoot.innerHTML = render(state);
-}
-
-root.addEventListener("click", (event) => {
+appRoot.addEventListener("pointerover", (event) => {
   const target = event.target;
   if (!(target instanceof Element)) {
     return;
   }
 
-  const playerButton = target.closest<HTMLButtonElement>("[data-player]");
+  const cardButton = target.closest<HTMLButtonElement>("[data-card-id]");
+  if (cardButton === null) {
+    return;
+  }
+  if (
+    event.relatedTarget instanceof Node &&
+    cardButton.contains(event.relatedTarget)
+  ) {
+    return;
+  }
+
+  clearZoomTimer();
+  const cardId = cardButton.dataset["cardId"] ?? null;
+  zoomTimer = window.setTimeout(() => {
+    showZoomPreview(cardId);
+  }, 650);
+});
+
+appRoot.addEventListener("pointerout", (event) => {
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return;
+  }
+
+  const cardButton = target.closest<HTMLButtonElement>("[data-card-id]");
+  if (cardButton === null) {
+    return;
+  }
+  if (
+    event.relatedTarget instanceof Node &&
+    cardButton.contains(event.relatedTarget)
+  ) {
+    return;
+  }
+
+  clearZoomTimer();
+  hideZoomPreview();
+});
+
+appRoot.addEventListener("click", (event) => {
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return;
+  }
+
+  const playerButton = target.closest<HTMLButtonElement>("[data-player-id]");
   if (playerButton !== null) {
-    const playerId = playerButton.dataset["player"];
-    if (isPlayerId(playerId)) {
-      commit(selectPlayer(state, playerId));
-    }
+    state = {
+      ...state,
+      activePlayerId: playerButton.dataset["playerId"] ?? state.activePlayerId,
+    };
+    render();
     return;
   }
 
-  const cardButton = target.closest<HTMLButtonElement>("[data-card]");
+  const cardButton = target.closest<HTMLButtonElement>("[data-card-id]");
   if (cardButton !== null) {
-    commit(selectCard(state, cardButton.dataset["card"] ?? null));
-    return;
-  }
-
-  const playButton = target.closest<HTMLButtonElement>("[data-play]");
-  if (playButton !== null) {
-    const destination = playButton.dataset["play"];
-    if (isPlayDestination(destination)) {
-      commit(nextTurn(playSelected(state, destination)));
-    }
+    const cardId = cardButton.dataset["cardId"] ?? state.selectedCardId;
+    const card = cards.find((candidate) => candidate.id === cardId);
+    state = {
+      ...state,
+      selectedCardId: cardId,
+      activePlayerId: card?.ownerId ?? state.activePlayerId,
+    };
+    hideZoomPreview();
+    render();
     return;
   }
 
@@ -66,54 +352,255 @@ root.addEventListener("click", (event) => {
     return;
   }
 
-  switch (actionButton.dataset["action"]) {
-    case "new": {
-      const seed = window.prompt("Seed", String(Date.now()));
-      if (seed !== null) {
-        clearSavedGame();
-        commit(createGame(seed));
-      }
-      break;
-    }
-    case "save":
-      saveGame(state);
-      commit(state, false);
-      break;
-    case "load": {
-      const loaded = loadGame();
-      if (loaded !== null) {
-        commit(loaded, false);
-      }
-      break;
-    }
-    case "cycle":
-      commit(cycleSelected(state));
-      break;
-    case "ring":
-      commit(useRingToken(state));
-      break;
-    case "pass":
-      commit(pass(state));
-      break;
-    case "resolve":
-      commit(resolveCombat(state));
-      break;
-    default:
-      break;
-  }
+  const action = actionButton.dataset["action"] ?? "";
+  state = {
+    ...state,
+    combatPulse: state.combatPulse + 1,
+    log: [
+      {
+        id: Date.now(),
+        text: actionLog(action, selectedCard().title),
+      },
+      ...state.log.slice(0, 9),
+    ],
+  };
+  render();
 });
 
-commit(state, false);
+render();
 
-function isPlayerId(value: string | undefined): value is PlayerId {
-  return (
-    value === "frodo" ||
-    value === "aragorn" ||
-    value === "witchKing" ||
-    value === "saruman"
-  );
+function render(): void {
+  appRoot.innerHTML = `
+    <main class="game-shell" aria-label="War of the Ring table mockup">
+      <header class="hud">
+        <section class="identity" aria-label="Game">
+          <span class="sigil" aria-hidden="true">W</span>
+          <div>
+            <h1>War of the Ring</h1>
+            <p>Round 3 - action phase - seed table-demo</p>
+          </div>
+        </section>
+        <section class="score-track" aria-label="Score">
+          <div><span>Free Peoples</span><strong>7</strong></div>
+          <div><span>Shadow</span><strong>6</strong></div>
+          <div><span>Burden</span><strong>2</strong></div>
+        </section>
+        <nav class="actions" aria-label="Mock actions">
+          <button type="button" data-action="play">Play</button>
+          <button type="button" data-action="reserve">Reserve</button>
+          <button type="button" data-action="cycle">Cycle</button>
+          <button type="button" data-action="resolve">Resolve</button>
+        </nav>
+      </header>
+
+      <section class="table-layout">
+        <section class="table-stage" aria-label="Four player table">
+          ${players.map((player) => playerSeat(player)).join("")}
+          <section class="felt-table ${state.combatPulse % 2 === 0 ? "" : "pulse"}" aria-label="Play area">
+            <div class="table-rim" aria-hidden="true"></div>
+            <div class="center-zone battleground-zone">
+              <div class="zone-title">
+                <span>Battleground</span>
+                <strong>Minas Tirith</strong>
+                <small>Defense 3 - VP 3</small>
+                <p>Dunedain player MAY forsake 1 card to draw 3 cards.</p>
+              </div>
+              <div class="lane">
+                ${cardsInZone("battle").map((card) => cardView(card, "table")).join("")}
+              </div>
+            </div>
+            <div class="center-zone path-zone">
+              <div class="zone-title">
+                <span>Path</span>
+                <strong>Cirith Ungol</strong>
+                <small>Path 8 - VP 2</small>
+                <p>The Mordor player draws 5 cards, may play 1 Army and cycles rest.</p>
+              </div>
+              <div class="lane">
+                ${cardsInZone("path").map((card) => cardView(card, "table")).join("")}
+              </div>
+            </div>
+            <div class="table-piles" aria-label="Shared piles">
+              ${pile("Free battlegrounds", 5, "free")}
+              ${pile("Shadow battlegrounds", 6, "shadow")}
+              ${pile("Path deck", 3, "path")}
+            </div>
+          </section>
+        </section>
+
+        <aside class="event-log" aria-label="Event log">
+          <div class="panel-head">
+            <span>Event Log</span>
+            <strong>${state.log.length}</strong>
+          </div>
+          <ol>
+            ${state.log.map((entry) => `<li>${escapeHtml(entry.text)}</li>`).join("")}
+          </ol>
+          <section class="selection">
+            <span>Selected</span>
+            ${cardInspector(selectedCard())}
+          </section>
+        </aside>
+      </section>
+    </main>
+  `;
 }
 
-function isPlayDestination(value: string | undefined): value is PlayDestination {
-  return value === "reserve" || value === "battleground" || value === "path";
+function playerSeat(player: PlayerMock): string {
+  const active = player.id === state.activePlayerId ? " active" : "";
+  const handCards = cards.filter(
+    (card) => card.ownerId === player.id && card.zone === "hand",
+  );
+  return `
+    <section class="seat seat-${player.seat}${active}" aria-label="${escapeHtml(player.name)} seat">
+      <button class="player-chip" type="button" data-player-id="${player.id}">
+        <span>${escapeHtml(player.name)}</span>
+        <small>${player.side === "free" ? "Free Peoples" : "Shadow"} - ${player.handCount} cards</small>
+      </button>
+      <div class="hand-fan" style="--cards: ${handCards.length}">
+        ${handCards.map((card, index) => cardView(card, "hand", index)).join("")}
+      </div>
+      <div class="personal-piles" aria-label="${escapeHtml(player.name)} piles">
+        ${pile("Draw", player.deckCount, player.side)}
+        ${pile("Cycle", player.cycleCount, "neutral")}
+        ${pile("Eliminated", player.eliminatedCount, "spent")}
+      </div>
+    </section>
+  `;
+}
+
+function cardView(card: CardMock, context: "hand" | "table", index = 0): string {
+  const selected = card.id === state.selectedCardId ? " selected" : "";
+  return `
+    <button
+      class="game-card ${context}${selected}"
+      type="button"
+      data-card-id="${card.id}"
+      style="--i: ${index}; --tone: ${toneFor(card.title)}"
+      aria-pressed="${card.id === state.selectedCardId ? "true" : "false"}"
+    >
+      <span class="card-kind">${escapeHtml(card.kind)}</span>
+      <strong>${escapeHtml(card.title)}</strong>
+      <span class="card-art art-${card.art}" aria-hidden="true">
+        <i></i><b></b><em></em>
+      </span>
+      <span class="card-meta">
+        <small>${escapeHtml(card.faction)}</small>
+        <mark>${escapeHtml(card.strength)}</mark>
+      </span>
+      <p>${escapeHtml(card.text)}</p>
+    </button>
+  `;
+}
+
+function cardInspector(card: CardMock): string {
+  return `
+    <article class="inspector-card">
+      <div class="mini-art art-${card.art}" aria-hidden="true"><i></i><b></b><em></em></div>
+      <div>
+        <strong>${escapeHtml(card.title)}</strong>
+        <p>${escapeHtml(card.faction)} ${escapeHtml(card.kind)} - ${escapeHtml(card.text)}</p>
+      </div>
+    </article>
+  `;
+}
+
+function zoomCard(card: CardMock): string {
+  return `
+    <aside class="zoom-preview" aria-live="polite" aria-label="Card preview">
+      <article class="zoom-card" style="--tone: ${toneFor(card.title)}">
+        <span class="card-kind">${escapeHtml(card.kind)}</span>
+        <strong>${escapeHtml(card.title)}</strong>
+        <span class="card-art art-${card.art}" aria-hidden="true">
+          <i></i><b></b><em></em>
+        </span>
+        <span class="card-meta">
+          <small>${escapeHtml(card.faction)}</small>
+          <mark>${escapeHtml(card.strength)}</mark>
+        </span>
+        <p>${escapeHtml(card.text)}</p>
+      </article>
+    </aside>
+  `;
+}
+
+function pile(label: string, count: number, tone: string): string {
+  return `
+    <div class="pile pile-${tone}">
+      <span class="stack" aria-hidden="true"></span>
+      <span>${escapeHtml(label)}</span>
+      <strong>${count}</strong>
+    </div>
+  `;
+}
+
+function cardsInZone(zone: CardZone): readonly CardMock[] {
+  return cards.filter((card) => card.zone === zone);
+}
+
+function selectedCard(): CardMock {
+  const fallback = cards[0];
+  if (fallback === undefined) {
+    throw new Error("Mock UI requires at least one card");
+  }
+  return cards.find((card) => card.id === state.selectedCardId) ?? fallback;
+}
+
+function clearZoomTimer(): void {
+  if (zoomTimer !== null) {
+    window.clearTimeout(zoomTimer);
+    zoomTimer = null;
+  }
+}
+
+function showZoomPreview(cardId: string | null): void {
+  const card =
+    cardId === null
+      ? selectedCard()
+      : cards.find((candidate) => candidate.id === cardId) ?? selectedCard();
+  hideZoomPreview();
+  const container = document.createElement("div");
+  container.innerHTML = zoomCard(card).trim();
+  const preview = container.firstElementChild;
+  if (preview instanceof HTMLElement) {
+    document.body.append(preview);
+    zoomPreview = preview;
+  }
+}
+
+function hideZoomPreview(): void {
+  zoomPreview?.remove();
+  zoomPreview = null;
+}
+
+function actionLog(action: string, title: string): string {
+  switch (action) {
+    case "play":
+      return `${title} slides from hand toward the active table zone.`;
+    case "reserve":
+      return `${title} is staged in reserve for a later window.`;
+    case "cycle":
+      return `${title} cycles with a new card drawn from the pile.`;
+    case "resolve":
+      return `Combat resolves at Minas Tirith; committed cards pulse on the felt.`;
+    default:
+      return `${title} was inspected.`;
+  }
+}
+
+function toneFor(value: string): string {
+  let hash = 0;
+  for (const char of value) {
+    hash = (hash * 31 + char.charCodeAt(0)) % 360;
+  }
+  return `${hash}deg`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,274 +1,58 @@
 import "./styles.css";
+import { players, turnOrder } from "./data";
+import {
+  canMoveTo,
+  canPlayTo,
+  createGame,
+  cycleSelected,
+  discardOversizedHands,
+  getBattlegroundDefinition,
+  getCard,
+  getCardDefinition,
+  getPathDefinition,
+  moveFromReserve,
+  nextTurn,
+  pass,
+  phaseLabel,
+  playSelected,
+  resolveCombat,
+  selectCard,
+  selectPlayer,
+  useRingToken,
+} from "./game";
+import { clearSavedGame, loadGame, saveGame } from "./storage";
+import type {
+  CardDefinition,
+  CardType,
+  GameState,
+  PlayDestination,
+  PlayerId,
+  Side,
+} from "./types";
 
 type Seat = "north" | "east" | "south" | "west";
-type Side = "free" | "shadow";
-type CardKind = "army" | "character" | "event" | "item";
-type CardZone = "hand" | "reserve" | "battle" | "path";
+type CardContext = "hand" | "table";
+type RealCardView = {
+  readonly instanceId: string;
+  readonly ownerId: PlayerId;
+  readonly definition: CardDefinition;
+};
 
-interface PlayerMock {
-  readonly id: string;
-  readonly name: string;
-  readonly seat: Seat;
-  readonly side: Side;
-  readonly handCount: number;
-  readonly deckCount: number;
-  readonly cycleCount: number;
-  readonly eliminatedCount: number;
-}
-
-interface CardMock {
-  readonly id: string;
-  readonly ownerId: string;
-  readonly title: string;
-  readonly faction: string;
-  readonly kind: CardKind;
-  readonly zone: CardZone;
-  readonly art: string;
-  readonly strength: string;
-  readonly text: string;
-}
-
-interface LogEntry {
-  readonly id: number;
-  readonly text: string;
-}
-
-interface UiState {
-  activePlayerId: string;
-  selectedCardId: string;
-  combatPulse: number;
-  log: readonly LogEntry[];
-}
-
-const players: readonly PlayerMock[] = [
-  {
-    id: "frodo",
-    name: "Frodo",
-    seat: "south",
-    side: "free",
-    handCount: 6,
-    deckCount: 18,
-    cycleCount: 4,
-    eliminatedCount: 1,
-  },
-  {
-    id: "witchKing",
-    name: "Witch-king",
-    seat: "west",
-    side: "shadow",
-    handCount: 5,
-    deckCount: 21,
-    cycleCount: 3,
-    eliminatedCount: 2,
-  },
-  {
-    id: "aragorn",
-    name: "Aragorn",
-    seat: "north",
-    side: "free",
-    handCount: 5,
-    deckCount: 16,
-    cycleCount: 6,
-    eliminatedCount: 0,
-  },
-  {
-    id: "saruman",
-    name: "Saruman",
-    seat: "east",
-    side: "shadow",
-    handCount: 7,
-    deckCount: 23,
-    cycleCount: 2,
-    eliminatedCount: 1,
-  },
-];
-
-const cards: readonly CardMock[] = [
-  {
-    id: "sting",
-    ownerId: "frodo",
-    title: "Sting",
-    faction: "Hobbit",
-    kind: "item",
-    zone: "hand",
-    art: "blade",
-    strength: "+1",
-    text: "If the wielder is on a path with a Monstrous Character then add 1 Defense token to the active path.",
-  },
-  {
-    id: "samwise",
-    ownerId: "frodo",
-    title: "Samwise the Brave",
-    faction: "Hobbit",
-    kind: "character",
-    zone: "hand",
-    art: "shire",
-    strength: "2",
-    text: "If eliminated in path combat, cycle instead along with any wielded items.",
-  },
-  {
-    id: "mithril",
-    ownerId: "frodo",
-    title: "Mithril Coat",
-    faction: "Dwarf",
-    kind: "item",
-    zone: "hand",
-    art: "mail",
-    strength: "+2",
-    text: "No rules text. Adds 2 path icons while wielded by Frodo or Sam.",
-  },
-  {
-    id: "gandalf",
-    ownerId: "frodo",
-    title: "Gandalf the White",
-    faction: "Wizard",
-    kind: "character",
-    zone: "reserve",
-    art: "wizard",
-    strength: "3",
-    text: "When played remove GtG from the game; while in reserve draw +1 card in each Draw step. If forsaken from top of the draw deck, cycle instead.",
-  },
-  {
-    id: "anduril",
-    ownerId: "aragorn",
-    title: "Anduril",
-    faction: "Dunedain",
-    kind: "item",
-    zone: "hand",
-    art: "sword",
-    strength: "+3",
-    text: "No rules text. Item wielded by Strider or Aragorn with 1 attack icon, 1 defense icon, and 1 path icon.",
-  },
-  {
-    id: "legolas",
-    ownerId: "aragorn",
-    title: "Legolas",
-    faction: "Elf",
-    kind: "character",
-    zone: "hand",
-    art: "forest",
-    strength: "3",
-    text: "When played you may take the Bow of Galadhrim from your draw deck into hand.",
-  },
-  {
-    id: "elrond",
-    ownerId: "aragorn",
-    title: "Elrond",
-    faction: "Elf",
-    kind: "character",
-    zone: "reserve",
-    art: "council",
-    strength: "3",
-    text: "When played draw 1 card. While in reserve increase your carryover limit by 1.",
-  },
-  {
-    id: "mordor-host",
-    ownerId: "witchKing",
-    title: "Mordor Orcs",
-    faction: "Mordor",
-    kind: "army",
-    zone: "hand",
-    art: "mordor",
-    strength: "4",
-    text: "No rules text. Mordor army card with 1 attack icon and 1 defense icon.",
-  },
-  {
-    id: "black-captain",
-    ownerId: "witchKing",
-    title: "The Black Captain",
-    faction: "Mordor",
-    kind: "event",
-    zone: "hand",
-    art: "wraith",
-    strength: "3",
-    text: "If the Witch-King is in reserve (active or not), (re)activate any Mordor battleground, then you MAY move the Witch-King to this battleground.",
-  },
-  {
-    id: "fell-beast",
-    ownerId: "witchKing",
-    title: "Fell Beast",
-    faction: "Mordor",
-    kind: "item",
-    zone: "battle",
-    art: "beast",
-    strength: "2",
-    text: "When played on a Nazgul in reserve (active or not), you may immediately move them to a battleground.",
-  },
-  {
-    id: "orthanc",
-    ownerId: "saruman",
-    title: "Palantir",
-    faction: "Isengard",
-    kind: "event",
-    zone: "hand",
-    art: "tower",
-    strength: "E",
-    text: "If Saruman is in reserve (active or not), (re)activate any Isengard battleground of your choice, then you MAY move Saruman to that battleground.",
-  },
-  {
-    id: "uruk-hai",
-    ownerId: "saruman",
-    title: "Fighting Uruk-Hai",
-    faction: "Isengard",
-    kind: "army",
-    zone: "hand",
-    art: "uruk",
-    strength: "3",
-    text: "No rules text. Isengard army with battleground attack and defense icons.",
-  },
-  {
-    id: "southron",
-    ownerId: "saruman",
-    title: "The Black Serpent",
-    faction: "Southron",
-    kind: "character",
-    zone: "path",
-    art: "desert",
-    strength: "E",
-    text: "If in reserve you may use your action and eliminate this card to reactivate any Southron battleground.",
-  },
-  {
-    id: "gimli",
-    ownerId: "frodo",
-    title: "Gimli",
-    faction: "Dwarf",
-    kind: "character",
-    zone: "battle",
-    art: "axe",
-    strength: "3",
-    text: "When played you may take \"Dwarevn Axe\" from your cycle pile into your hand.",
-  },
-  {
-    id: "gollum",
-    ownerId: "saruman",
-    title: "Gollum",
-    faction: "Monstrous",
-    kind: "character",
-    zone: "path",
-    art: "cavern",
-    strength: "E",
-    text: "If on a path you may use your action to activate a different path of the same #. If Gollum is eliminated in path combat, cycle instead.",
-  },
-];
-
-let state: UiState = {
-  activePlayerId: "frodo",
-  selectedCardId: "sting",
-  combatPulse: 0,
-  log: [
-    { id: 5, text: "Fell Beast committed to Minas Tirith." },
-    { id: 4, text: "Gimli answered the battleground call." },
-    { id: 3, text: "Southron Ambush moved onto the path." },
-    { id: 2, text: "Frodo held Mithril Coat in reserve range." },
-    { id: 1, text: "Round 3 action phase began from seed table-demo." },
-  ],
+const playerSeats: Readonly<Record<PlayerId, Seat>> = {
+  frodo: "south",
+  witchKing: "west",
+  aragorn: "north",
+  saruman: "east",
 };
 
 const root = document.querySelector<HTMLDivElement>("#app");
 if (root === null) {
   throw new Error("Missing #app root");
 }
+
 const appRoot = root;
+let state = loadGame() ?? createGame("middle-earth");
+let combatPulse = 0;
 let zoomTimer: number | null = null;
 let zoomPreview: HTMLElement | null = null;
 
@@ -290,9 +74,9 @@ appRoot.addEventListener("pointerover", (event) => {
   }
 
   clearZoomTimer();
-  const cardId = cardButton.dataset["cardId"] ?? null;
+  const instanceId = cardButton.dataset["cardId"] ?? null;
   zoomTimer = window.setTimeout(() => {
-    showZoomPreview(cardId);
+    showZoomPreview(instanceId);
   }, 650);
 });
 
@@ -325,25 +109,21 @@ appRoot.addEventListener("click", (event) => {
 
   const playerButton = target.closest<HTMLButtonElement>("[data-player-id]");
   if (playerButton !== null) {
-    state = {
-      ...state,
-      activePlayerId: playerButton.dataset["playerId"] ?? state.activePlayerId,
-    };
-    render();
+    const playerId = playerButton.dataset["playerId"];
+    if (isPlayerId(playerId)) {
+      commit(selectPlayer(state, playerId));
+    }
     return;
   }
 
   const cardButton = target.closest<HTMLButtonElement>("[data-card-id]");
   if (cardButton !== null) {
-    const cardId = cardButton.dataset["cardId"] ?? state.selectedCardId;
-    const card = cards.find((candidate) => candidate.id === cardId);
-    state = {
-      ...state,
-      selectedCardId: cardId,
-      activePlayerId: card?.ownerId ?? state.activePlayerId,
-    };
+    const instanceId = cardButton.dataset["cardId"] ?? null;
+    const ownerId = instanceId === null ? null : ownerForCard(state, instanceId);
+    let nextState = ownerId === null ? state : selectPlayer(state, ownerId);
+    nextState = selectCard(nextState, instanceId);
     hideZoomPreview();
-    render();
+    commit(nextState, false);
     return;
   }
 
@@ -352,78 +132,125 @@ appRoot.addEventListener("click", (event) => {
     return;
   }
 
-  const action = actionButton.dataset["action"] ?? "";
-  state = {
-    ...state,
-    combatPulse: state.combatPulse + 1,
-    log: [
-      {
-        id: Date.now(),
-        text: actionLog(action, selectedCard().title),
-      },
-      ...state.log.slice(0, 9),
-    ],
-  };
-  render();
+  runAction(actionButton.dataset["action"] ?? "");
 });
 
 render();
 
+function runAction(action: string): void {
+  switch (action) {
+    case "new": {
+      const seed = window.prompt("Seed", state.seed);
+      if (seed !== null) {
+        clearSavedGame();
+        combatPulse = 0;
+        commit(createGame(seed));
+      }
+      return;
+    }
+    case "play":
+      commit(playOrMoveSelected());
+      return;
+    case "reserve":
+      commit(playReserveSelected());
+      return;
+    case "cycle":
+      commit(cycleSelected(state));
+      return;
+    case "ring":
+      commit(useRingToken(state));
+      return;
+    case "pass":
+      commit(pass(state));
+      return;
+    case "resolve":
+      combatPulse += 1;
+      commit(resolveCombat(state));
+      return;
+    default:
+      return;
+  }
+}
+
+function playOrMoveSelected(): GameState {
+  const instanceId = state.selection.cardId;
+  const playerId = state.selection.playerId;
+  if (instanceId === null) {
+    return state;
+  }
+  const player = state.players[playerId];
+  if (player.reserve.includes(instanceId)) {
+    const destination = bestMoveDestination(state, playerId, instanceId);
+    return destination === null
+      ? state
+      : nextTurn(moveFromReserve(state, playerId, instanceId, destination));
+  }
+  const destination = bestPlayDestination(state, playerId, instanceId);
+  return destination === null
+    ? state
+    : nextTurn(playSelected(state, destination));
+}
+
+function playReserveSelected(): GameState {
+  const instanceId = state.selection.cardId;
+  const playerId = state.selection.playerId;
+  if (
+    instanceId === null ||
+    !state.players[playerId].hand.includes(instanceId) ||
+    !canPlayTo(state, playerId, instanceId, "reserve")
+  ) {
+    return state;
+  }
+  return nextTurn(playSelected(state, "reserve"));
+}
+
+function commit(nextState: GameState, shouldSave = true): void {
+  state = discardOversizedHands(nextState);
+  if (shouldSave) {
+    saveGame(state);
+  }
+  render();
+}
+
 function render(): void {
+  const selected = selectedCard();
   appRoot.innerHTML = `
-    <main class="game-shell" aria-label="War of the Ring table mockup">
+    <main class="game-shell" aria-label="War of the Ring table">
       <header class="hud">
         <section class="identity" aria-label="Game">
           <span class="sigil" aria-hidden="true">W</span>
           <div>
             <h1>War of the Ring</h1>
-            <p>Round 3 - action phase - seed table-demo</p>
+            <p>Round ${state.round} - ${phaseLabel(state.phase)} - seed ${escapeHtml(state.seed)}</p>
           </div>
         </section>
         <section class="score-track" aria-label="Score">
-          <div><span>Free Peoples</span><strong>7</strong></div>
-          <div><span>Shadow</span><strong>6</strong></div>
-          <div><span>Burden</span><strong>2</strong></div>
+          <div><span>Free Peoples</span><strong>${state.score.free}</strong></div>
+          <div><span>Shadow</span><strong>${state.score.shadow}</strong></div>
+          <div><span>Burden</span><strong>${state.corruption.tokens}</strong></div>
         </section>
-        <nav class="actions" aria-label="Mock actions">
-          <button type="button" data-action="play">Play</button>
-          <button type="button" data-action="reserve">Reserve</button>
-          <button type="button" data-action="cycle">Cycle</button>
+        <nav class="actions" aria-label="Game actions">
+          <button type="button" data-action="new">New</button>
+          <button type="button" data-action="play" ${canPlayOrMoveSelected() ? "" : "disabled"}>Play</button>
+          <button type="button" data-action="reserve" ${canReserveSelected() ? "" : "disabled"}>Reserve</button>
+          <button type="button" data-action="cycle" ${canCycleSelected() ? "" : "disabled"}>Cycle</button>
+          <button type="button" data-action="ring">Ring</button>
+          <button type="button" data-action="pass">Pass</button>
           <button type="button" data-action="resolve">Resolve</button>
         </nav>
       </header>
 
       <section class="table-layout">
         <section class="table-stage" aria-label="Four player table">
-          ${players.map((player) => playerSeat(player)).join("")}
-          <section class="felt-table ${state.combatPulse % 2 === 0 ? "" : "pulse"}" aria-label="Play area">
+          ${turnOrder.map((playerId) => playerSeat(playerId)).join("")}
+          <section class="felt-table ${combatPulse % 2 === 0 ? "" : "pulse"}" aria-label="Play area">
             <div class="table-rim" aria-hidden="true"></div>
-            <div class="center-zone battleground-zone">
-              <div class="zone-title">
-                <span>Battleground</span>
-                <strong>Minas Tirith</strong>
-                <small>Defense 3 - VP 3</small>
-                <p>Dunedain player MAY forsake 1 card to draw 3 cards.</p>
-              </div>
-              <div class="lane">
-                ${cardsInZone("battle").map((card) => cardView(card, "table")).join("")}
-              </div>
-            </div>
-            <div class="center-zone path-zone">
-              <div class="zone-title">
-                <span>Path</span>
-                <strong>Cirith Ungol</strong>
-                <small>Path 8 - VP 2</small>
-                <p>The Mordor player draws 5 cards, may play 1 Army and cycles rest.</p>
-              </div>
-              <div class="lane">
-                ${cardsInZone("path").map((card) => cardView(card, "table")).join("")}
-              </div>
-            </div>
+            ${battlegroundZone()}
+            ${pathZone()}
             <div class="table-piles" aria-label="Shared piles">
-              ${pile("Free battlegrounds", 5, "free")}
-              ${pile("Shadow battlegrounds", 6, "shadow")}
-              ${pile("Path deck", 3, "path")}
+              ${pile("Free battlegrounds", state.battlegroundDecks.free.length, "free")}
+              ${pile("Shadow battlegrounds", state.battlegroundDecks.shadow.length, "shadow")}
+              ${pile("Path deck", state.pathDeck.length, "path")}
             </div>
           </section>
         </section>
@@ -434,11 +261,15 @@ function render(): void {
             <strong>${state.log.length}</strong>
           </div>
           <ol>
-            ${state.log.map((entry) => `<li>${escapeHtml(entry.text)}</li>`).join("")}
+            ${state.log
+              .slice()
+              .reverse()
+              .map((entry) => `<li>${escapeHtml(entry.message)}</li>`)
+              .join("")}
           </ol>
           <section class="selection">
             <span>Selected</span>
-            ${cardInspector(selectedCard())}
+            ${selected === null ? `<p class="empty-selection">No card selected</p>` : cardInspector(selected)}
           </section>
         </aside>
       </section>
@@ -446,79 +277,157 @@ function render(): void {
   `;
 }
 
-function playerSeat(player: PlayerMock): string {
-  const active = player.id === state.activePlayerId ? " active" : "";
-  const handCards = cards.filter(
-    (card) => card.ownerId === player.id && card.zone === "hand",
-  );
+function playerSeat(playerId: PlayerId): string {
+  const player = state.players[playerId];
+  const definition = players[playerId];
+  const active = state.activePlayer === playerId ? " active" : "";
+  const handCards = player.hand.map((instanceId) => cardViewModel(instanceId));
+  const reserveCards = player.reserve.map((instanceId) => cardViewModel(instanceId));
   return `
-    <section class="seat seat-${player.seat}${active}" aria-label="${escapeHtml(player.name)} seat">
-      <button class="player-chip" type="button" data-player-id="${player.id}">
-        <span>${escapeHtml(player.name)}</span>
-        <small>${player.side === "free" ? "Free Peoples" : "Shadow"} - ${player.handCount} cards</small>
+    <section class="seat seat-${playerSeats[playerId]}${active}" aria-label="${escapeHtml(definition.name)} seat">
+      <button class="player-chip" type="button" data-player-id="${playerId}">
+        <span>${escapeHtml(definition.name)}</span>
+        <small>${definition.side === "free" ? "Free Peoples" : "Shadow"} - ${player.hand.length} cards</small>
       </button>
       <div class="hand-fan" style="--cards: ${handCards.length}">
         ${handCards.map((card, index) => cardView(card, "hand", index)).join("")}
       </div>
-      <div class="personal-piles" aria-label="${escapeHtml(player.name)} piles">
-        ${pile("Draw", player.deckCount, player.side)}
-        ${pile("Cycle", player.cycleCount, "neutral")}
-        ${pile("Eliminated", player.eliminatedCount, "spent")}
+      ${
+        reserveCards.length === 0
+          ? ""
+          : `<div class="reserve-strip" aria-label="${escapeHtml(definition.name)} reserve">${reserveCards
+              .map((card, index) => cardView(card, "table", index))
+              .join("")}</div>`
+      }
+      <div class="personal-piles" aria-label="${escapeHtml(definition.name)} piles">
+        ${pile("Draw", player.draw.length, definition.side)}
+        ${pile("Cycle", player.cycle.length, "neutral")}
+        ${pile("Eliminated", player.eliminated.length, "spent")}
       </div>
     </section>
   `;
 }
 
-function cardView(card: CardMock, context: "hand" | "table", index = 0): string {
-  const selected = card.id === state.selectedCardId ? " selected" : "";
+function battlegroundZone(): string {
+  const active = state.activeBattleground;
+  if (active === null) {
+    return `
+      <div class="center-zone battleground-zone">
+        <div class="zone-title">
+          <span>Battleground</span>
+          <strong>No battleground</strong>
+          <small>Waiting for round setup</small>
+        </div>
+        <div class="lane"></div>
+      </div>
+    `;
+  }
+  const definition = getBattlegroundDefinition(active.id);
+  const title = definition?.title ?? "Unknown battleground";
+  const defense = definition?.defenseIcons ?? active.defenseTokens;
+  const victoryPoints = definition?.victoryPoints ?? 0;
+  const text = definition?.text ?? "No location text.";
+  return `
+    <div class="center-zone battleground-zone">
+      <div class="zone-title">
+        <span>Battleground</span>
+        <strong>${escapeHtml(title)}</strong>
+        <small>Defense ${defense} - VP ${victoryPoints}</small>
+        <p>${escapeHtml(text || "No location text.")}</p>
+      </div>
+      <div class="lane">
+        ${active.cards.map((instanceId) => cardView(cardViewModel(instanceId), "table")).join("")}
+      </div>
+    </div>
+  `;
+}
+
+function pathZone(): string {
+  const active = state.activePath;
+  if (active === null) {
+    return `
+      <div class="center-zone path-zone">
+        <div class="zone-title">
+          <span>Path</span>
+          <strong>No path</strong>
+          <small>Waiting for round setup</small>
+        </div>
+        <div class="lane"></div>
+      </div>
+    `;
+  }
+  const definition = getPathDefinition(active.id);
+  const title = definition?.title ?? "Unknown path";
+  const pathNumber = definition?.pathNumber ?? state.currentPathNumber;
+  const victoryPoints = definition?.victoryPoints ?? 0;
+  const text = definition?.text ?? "No path text.";
+  return `
+    <div class="center-zone path-zone">
+      <div class="zone-title">
+        <span>Path</span>
+        <strong>${escapeHtml(title)}</strong>
+        <small>Path ${pathNumber} - VP ${victoryPoints} - Attack ${active.attackTokens} / Defense ${active.defenseTokens}</small>
+        <p>${escapeHtml(text || "No path text.")}</p>
+      </div>
+      <div class="lane">
+        ${active.cards.map((instanceId) => cardView(cardViewModel(instanceId), "table")).join("")}
+      </div>
+    </div>
+  `;
+}
+
+function cardView(card: RealCardView, context: CardContext, index = 0): string {
+  const selected = card.instanceId === state.selection.cardId ? " selected" : "";
+  const strength = strengthText(card.definition);
+  const art = artKey(card.definition);
   return `
     <button
       class="game-card ${context}${selected}"
       type="button"
-      data-card-id="${card.id}"
-      style="--i: ${index}; --tone: ${toneFor(card.title)}"
-      aria-pressed="${card.id === state.selectedCardId ? "true" : "false"}"
+      data-card-id="${card.instanceId}"
+      style="--i: ${index}; --tone: ${toneFor(card.definition.title)}"
+      aria-pressed="${card.instanceId === state.selection.cardId ? "true" : "false"}"
     >
-      <span class="card-kind">${escapeHtml(card.kind)}</span>
-      <strong>${escapeHtml(card.title)}</strong>
-      <span class="card-art art-${card.art}" aria-hidden="true">
+      <span class="card-kind">${escapeHtml(card.definition.type)}</span>
+      <strong>${escapeHtml(card.definition.title)}</strong>
+      <span class="card-art art-${art}" aria-hidden="true">
         <i></i><b></b><em></em>
       </span>
       <span class="card-meta">
-        <small>${escapeHtml(card.faction)}</small>
-        <mark>${escapeHtml(card.strength)}</mark>
+        <small>${escapeHtml(card.definition.faction)}</small>
+        <mark>${escapeHtml(strength)}</mark>
       </span>
-      <p>${escapeHtml(card.text)}</p>
+      <p>${escapeHtml(card.definition.text || "No rules text.")}</p>
     </button>
   `;
 }
 
-function cardInspector(card: CardMock): string {
+function cardInspector(card: RealCardView): string {
   return `
     <article class="inspector-card">
-      <div class="mini-art art-${card.art}" aria-hidden="true"><i></i><b></b><em></em></div>
+      <div class="mini-art art-${artKey(card.definition)}" aria-hidden="true"><i></i><b></b><em></em></div>
       <div>
-        <strong>${escapeHtml(card.title)}</strong>
-        <p>${escapeHtml(card.faction)} ${escapeHtml(card.kind)} - ${escapeHtml(card.text)}</p>
+        <strong>${escapeHtml(card.definition.title)}</strong>
+        <p>${escapeHtml(card.definition.faction)} ${escapeHtml(card.definition.type)} - ${escapeHtml(card.definition.text || "No rules text.")}</p>
       </div>
     </article>
   `;
 }
 
-function zoomCard(card: CardMock): string {
+function zoomCard(card: RealCardView): string {
   return `
     <aside class="zoom-preview" aria-live="polite" aria-label="Card preview">
-      <article class="zoom-card" style="--tone: ${toneFor(card.title)}">
-        <span class="card-kind">${escapeHtml(card.kind)}</span>
-        <strong>${escapeHtml(card.title)}</strong>
-        <span class="card-art art-${card.art}" aria-hidden="true">
+      <article class="zoom-card" style="--tone: ${toneFor(card.definition.title)}">
+        <span class="card-kind">${escapeHtml(card.definition.type)}</span>
+        <strong>${escapeHtml(card.definition.title)}</strong>
+        <span class="card-art art-${artKey(card.definition)}" aria-hidden="true">
           <i></i><b></b><em></em>
         </span>
         <span class="card-meta">
-          <small>${escapeHtml(card.faction)}</small>
-          <mark>${escapeHtml(card.strength)}</mark>
+          <small>${escapeHtml(card.definition.faction)}</small>
+          <mark>${escapeHtml(strengthText(card.definition))}</mark>
         </span>
-        <p>${escapeHtml(card.text)}</p>
+        <p>${escapeHtml(card.definition.text || "No rules text.")}</p>
       </article>
     </aside>
   `;
@@ -534,30 +443,25 @@ function pile(label: string, count: number, tone: string): string {
   `;
 }
 
-function cardsInZone(zone: CardZone): readonly CardMock[] {
-  return cards.filter((card) => card.zone === zone);
+function selectedCard(): RealCardView | null {
+  const selected = state.selection.cardId;
+  return selected === null ? null : cardViewModel(selected);
 }
 
-function selectedCard(): CardMock {
-  const fallback = cards[0];
-  if (fallback === undefined) {
-    throw new Error("Mock UI requires at least one card");
+function cardViewModel(instanceId: string): RealCardView {
+  const instance = getCard(state, instanceId);
+  return {
+    instanceId,
+    ownerId: ownerForCard(state, instanceId) ?? getCardDefinition(instance.cardId).owner,
+    definition: getCardDefinition(instance.cardId),
+  };
+}
+
+function showZoomPreview(instanceId: string | null): void {
+  const card = instanceId === null ? selectedCard() : cardViewModel(instanceId);
+  if (card === null) {
+    return;
   }
-  return cards.find((card) => card.id === state.selectedCardId) ?? fallback;
-}
-
-function clearZoomTimer(): void {
-  if (zoomTimer !== null) {
-    window.clearTimeout(zoomTimer);
-    zoomTimer = null;
-  }
-}
-
-function showZoomPreview(cardId: string | null): void {
-  const card =
-    cardId === null
-      ? selectedCard()
-      : cards.find((candidate) => candidate.id === cardId) ?? selectedCard();
   hideZoomPreview();
   const container = document.createElement("div");
   container.innerHTML = zoomCard(card).trim();
@@ -573,19 +477,155 @@ function hideZoomPreview(): void {
   zoomPreview = null;
 }
 
-function actionLog(action: string, title: string): string {
-  switch (action) {
-    case "play":
-      return `${title} slides from hand toward the active table zone.`;
-    case "reserve":
-      return `${title} is staged in reserve for a later window.`;
-    case "cycle":
-      return `${title} cycles with a new card drawn from the pile.`;
-    case "resolve":
-      return `Combat resolves at Minas Tirith; committed cards pulse on the felt.`;
-    default:
-      return `${title} was inspected.`;
+function clearZoomTimer(): void {
+  if (zoomTimer !== null) {
+    window.clearTimeout(zoomTimer);
+    zoomTimer = null;
   }
+}
+
+function canPlayOrMoveSelected(): boolean {
+  const instanceId = state.selection.cardId;
+  const playerId = state.selection.playerId;
+  if (instanceId === null) {
+    return false;
+  }
+  if (state.players[playerId].reserve.includes(instanceId)) {
+    return bestMoveDestination(state, playerId, instanceId) !== null;
+  }
+  return bestPlayDestination(state, playerId, instanceId) !== null;
+}
+
+function canReserveSelected(): boolean {
+  const instanceId = state.selection.cardId;
+  const playerId = state.selection.playerId;
+  return (
+    instanceId !== null &&
+    state.players[playerId].hand.includes(instanceId) &&
+    canPlayTo(state, playerId, instanceId, "reserve")
+  );
+}
+
+function canCycleSelected(): boolean {
+  const instanceId = state.selection.cardId;
+  return instanceId !== null && state.players[state.selection.playerId].hand.includes(instanceId);
+}
+
+function bestPlayDestination(
+  gameState: GameState,
+  playerId: PlayerId,
+  instanceId: string,
+): PlayDestination | null {
+  if (canPlayTo(gameState, playerId, instanceId, "battleground")) {
+    return "battleground";
+  }
+  if (canPlayTo(gameState, playerId, instanceId, "path")) {
+    return "path";
+  }
+  if (canPlayTo(gameState, playerId, instanceId, "reserve")) {
+    return "reserve";
+  }
+  return null;
+}
+
+function bestMoveDestination(
+  gameState: GameState,
+  playerId: PlayerId,
+  instanceId: string,
+): Exclude<PlayDestination, "reserve"> | null {
+  if (canMoveTo(gameState, playerId, instanceId, "battleground")) {
+    return "battleground";
+  }
+  if (canMoveTo(gameState, playerId, instanceId, "path")) {
+    return "path";
+  }
+  return null;
+}
+
+function ownerForCard(gameState: GameState, instanceId: string): PlayerId | null {
+  for (const playerId of turnOrder) {
+    const player = gameState.players[playerId];
+    if (
+      player.hand.includes(instanceId) ||
+      player.reserve.includes(instanceId) ||
+      player.draw.includes(instanceId) ||
+      player.cycle.includes(instanceId) ||
+      player.eliminated.includes(instanceId)
+    ) {
+      return playerId;
+    }
+  }
+  const definition = getCardDefinition(getCard(gameState, instanceId).cardId);
+  return definition.owner;
+}
+
+function strengthText(card: CardDefinition): string {
+  if (card.type === "event") {
+    return "E";
+  }
+  const attack = card.battlegroundAttack + card.leadershipAttack;
+  const defense = card.battlegroundDefense + card.leadershipDefense;
+  if (attack === 0 && defense === 0 && card.pathIcons > 0) {
+    return `P${card.pathIcons}`;
+  }
+  if (attack === defense) {
+    return String(attack);
+  }
+  return `${attack}/${defense}`;
+}
+
+function artKey(card: CardDefinition): string {
+  if (card.type === "item") {
+    return itemArt(card.title);
+  }
+  if (card.type === "army") {
+    return card.faction === "isengard" ? "uruk" : card.faction;
+  }
+  if (card.faction === "elf") {
+    return "forest";
+  }
+  if (card.faction === "hobbit") {
+    return "shire";
+  }
+  if (card.faction === "wizard") {
+    return "wizard";
+  }
+  if (card.faction === "dwarf") {
+    return "axe";
+  }
+  if (card.faction === "mordor") {
+    return "wraith";
+  }
+  if (card.faction === "monstrous") {
+    return "beast";
+  }
+  if (card.faction === "southron") {
+    return "desert";
+  }
+  return "council";
+}
+
+function itemArt(title: string): string {
+  const lower = title.toLowerCase();
+  if (lower.includes("coat") || lower.includes("mail")) {
+    return "mail";
+  }
+  if (lower.includes("axe")) {
+    return "axe";
+  }
+  if (lower.includes("staff") || lower.includes("palantir")) {
+    return "tower";
+  }
+  return "sword";
+}
+
+function isPlayerId(value: string | undefined): value is PlayerId {
+  return (
+    value === "frodo" ||
+    value === "aragorn" ||
+    value === "witchKing" ||
+    value === "saruman"
+  );
 }
 
 function toneFor(value: string): string {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,8 +3,8 @@
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
-  background: #11110f;
-  color: #f4efe5;
+  color: #f8f1df;
+  background: #15110d;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
 }
@@ -14,372 +14,921 @@
 }
 
 body {
-  margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  margin: 0;
   background:
-    linear-gradient(rgba(17, 17, 15, 0.88), rgba(17, 17, 15, 0.94)),
-    url("/wotr.svg") center 5rem / min(72rem, 120vw) auto no-repeat fixed;
+    radial-gradient(circle at 50% 10%, rgba(198, 168, 96, 0.16), transparent 32rem),
+    linear-gradient(135deg, #1d1610 0%, #0e1312 52%, #19120d 100%);
 }
 
 button {
-  border: 1px solid #5d564c;
-  border-radius: 6px;
-  background: #24221e;
+  border: 0;
   color: inherit;
   font: inherit;
-  cursor: pointer;
 }
 
-button:hover:not(:disabled),
-button[aria-pressed="true"] {
-  border-color: #d5b36a;
-  background: #342b20;
-}
-
-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.45;
+button:focus-visible {
+  outline: 3px solid #e7bf55;
+  outline-offset: 3px;
 }
 
 h1,
-h2,
-p {
+p,
+ol {
   margin: 0;
 }
 
-.shell {
-  width: min(1440px, 100%);
-  margin: 0 auto;
-  padding: 16px;
-}
-
-.topbar,
-.board,
-.hand-row {
+.game-shell {
   display: grid;
-  gap: 12px;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 14px;
+  width: min(1760px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 14px;
 }
 
-.topbar {
-  grid-template-columns: minmax(0, 1fr) auto auto;
+.hud,
+.event-log,
+.player-chip,
+.score-track div,
+.actions button,
+.selection,
+.pile {
+  border: 1px solid rgba(248, 241, 223, 0.14);
+  background: rgba(22, 18, 14, 0.78);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(16px);
+}
+
+.hud {
+  display: grid;
+  grid-template-columns: minmax(18rem, 1fr) auto auto;
   align-items: center;
-  min-height: 82px;
-  border-bottom: 1px solid #3a332b;
-  padding-bottom: 12px;
+  gap: 12px;
+  min-height: 78px;
+  padding: 12px;
+  border-radius: 8px;
 }
 
-.brand {
+.identity {
   display: flex;
   align-items: center;
   gap: 12px;
   min-width: 0;
 }
 
-.brand img {
-  width: 56px;
-  height: 56px;
-  object-fit: cover;
-  border-radius: 6px;
-  background: #f4efe5;
-}
-
-.brand h1 {
-  font-size: clamp(1.2rem, 2vw, 1.85rem);
-  line-height: 1.1;
-}
-
-.brand p,
-.muted,
-.site p,
-.player-button small,
-.compact-card small {
-  color: #c8bdab;
-}
-
-.scoreboard {
+.sigil {
   display: grid;
-  grid-template-columns: repeat(2, minmax(92px, 1fr));
+  flex: 0 0 auto;
+  place-items: center;
+  width: 52px;
+  height: 52px;
+  border: 1px solid rgba(231, 191, 85, 0.55);
+  border-radius: 50%;
+  background:
+    linear-gradient(145deg, rgba(241, 213, 125, 0.22), rgba(88, 38, 25, 0.42)),
+    #2d2115;
+  color: #f7d56a;
+  font-family: Georgia, serif;
+  font-size: 1.55rem;
+  font-weight: 700;
+}
+
+.identity h1 {
+  margin: 0;
+  font-size: clamp(1.35rem, 2vw, 2rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.identity p,
+.score-track span,
+.player-chip small,
+.zone-title span,
+.zone-title small,
+.card-kind,
+.card-meta small,
+.event-log li,
+.selection span,
+.inspector-card p,
+.pile span {
+  color: #c9bea8;
+}
+
+.score-track,
+.actions {
+  display: grid;
+  grid-auto-flow: column;
   gap: 8px;
 }
 
-.scoreboard div,
-.zone,
-.site,
-.commands,
-.players {
-  border: 1px solid #3a332b;
-  background: rgba(18, 18, 16, 0.88);
-}
-
-.scoreboard div {
-  border-radius: 6px;
+.score-track div {
+  min-width: 94px;
+  border-radius: 7px;
   padding: 8px 10px;
 }
 
-.scoreboard span {
+.score-track span,
+.selection span {
   display: block;
-  color: #c8bdab;
-  font-size: 0.78rem;
-}
-
-.scoreboard strong {
-  font-size: 1.45rem;
-}
-
-.toolbar,
-.command-grid {
-  display: grid;
-  gap: 8px;
-}
-
-.toolbar {
-  grid-template-columns: repeat(3, auto);
-}
-
-.toolbar button,
-.command-grid button {
-  min-height: 38px;
-  padding: 0 12px;
-}
-
-.board {
-  grid-template-columns: 220px minmax(0, 1fr) 220px;
-  margin-top: 12px;
-}
-
-.players,
-.commands,
-.site,
-.zone {
-  border-radius: 8px;
-  padding: 12px;
-}
-
-.players {
-  display: grid;
-  gap: 8px;
-  align-content: start;
-}
-
-.player-button {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 2px 8px;
-  min-height: 58px;
-  padding: 10px;
-  text-align: left;
-}
-
-.player-button small {
-  grid-column: 1;
-}
-
-.player-button b {
-  grid-row: 1 / span 2;
-  grid-column: 2;
-  align-self: center;
-  color: #d5b36a;
-}
-
-.player-button.active {
-  box-shadow: inset 3px 0 0 #bd3d31;
-}
-
-.table {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  min-height: 320px;
-}
-
-.site {
-  display: grid;
-  align-content: start;
-  gap: 12px;
-}
-
-.site header span,
-.faction {
-  color: #d5b36a;
-  font-size: 0.76rem;
+  font-size: 0.72rem;
   text-transform: uppercase;
 }
 
-.site h2,
-.commands h2,
-.zone h2 {
-  font-size: 1rem;
+.score-track strong {
+  display: block;
+  margin-top: 2px;
+  color: #f3cc68;
+  font-size: 1.45rem;
+  line-height: 1;
 }
 
-.metrics,
-.icons {
+.actions button {
+  min-width: 78px;
+  min-height: 40px;
+  border-radius: 7px;
+  background:
+    linear-gradient(180deg, rgba(224, 178, 87, 0.2), rgba(113, 47, 32, 0.38)),
+    #2a2119;
+  cursor: pointer;
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease,
+    background 140ms ease;
+}
+
+.actions button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(231, 191, 85, 0.56);
+}
+
+.table-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 22vw);
+  gap: 14px;
+  min-height: 0;
+}
+
+.table-stage {
+  display: grid;
+  grid-template:
+    ". north ." auto
+    "west table east" minmax(500px, 1fr)
+    ". south ." auto / minmax(190px, 0.26fr) minmax(620px, 1fr) minmax(190px, 0.26fr);
+  gap: 12px;
+  min-height: 760px;
+  overflow: hidden;
+  border-radius: 8px;
+  background:
+    radial-gradient(ellipse at center, rgba(226, 188, 99, 0.16), transparent 42%),
+    linear-gradient(135deg, rgba(95, 60, 34, 0.36), rgba(33, 29, 22, 0.64));
+}
+
+.felt-table {
+  position: relative;
+  grid-area: table;
+  align-self: center;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 14px;
+  min-height: 430px;
+  padding: 34px;
+  border: 18px solid #5a3321;
+  border-radius: 42% / 30%;
+  background:
+    radial-gradient(ellipse at center, rgba(255, 255, 255, 0.08), transparent 52%),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.025) 0 1px, transparent 1px 17px),
+    #1f6a4e;
+  box-shadow:
+    inset 0 0 0 8px rgba(42, 24, 14, 0.72),
+    inset 0 0 80px rgba(0, 0, 0, 0.45),
+    0 34px 80px rgba(0, 0, 0, 0.46);
+}
+
+.felt-table.pulse .center-zone {
+  animation: combat-pulse 520ms ease both;
+}
+
+.table-rim {
+  position: absolute;
+  inset: -18px;
+  pointer-events: none;
+  border-radius: inherit;
+  box-shadow:
+    inset 0 5px 0 rgba(255, 226, 164, 0.12),
+    inset 0 -8px 0 rgba(0, 0, 0, 0.24);
+}
+
+.center-zone {
+  display: grid;
+  align-content: start;
+  gap: 12px;
+  min-width: 0;
+  min-height: 230px;
+  padding: 18px;
+  border: 1px solid rgba(247, 221, 158, 0.22);
+  border-radius: 8px;
+  background: rgba(5, 26, 19, 0.42);
+}
+
+.path-zone {
+  background: rgba(42, 34, 21, 0.5);
+}
+
+.zone-title {
+  display: grid;
+  gap: 2px;
+}
+
+.zone-title strong {
+  font-size: clamp(1rem, 1.4vw, 1.35rem);
+}
+
+.zone-title p {
+  max-width: 28ch;
+  margin-top: 4px;
+  color: #e2d6bd;
+  font-size: 0.84rem;
+  line-height: 1.25;
+}
+
+.lane {
   display: flex;
   flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.table-piles {
+  display: flex;
+  grid-column: 1 / -1;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-self: end;
+  justify-content: center;
+}
+
+.seat {
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+  z-index: 2;
+  min-width: 0;
+  padding: 8px;
+}
+
+.seat-north,
+.seat-south {
+  width: 100%;
+}
+
+.seat-north {
+  grid-area: north;
+}
+
+.seat-south {
+  grid-area: south;
+}
+
+.seat-west,
+.seat-east {
+  align-self: center;
+  width: 100%;
+}
+
+.seat-west {
+  grid-area: west;
+}
+
+.seat-east {
+  grid-area: east;
+}
+
+.player-chip {
+  display: grid;
+  min-width: 172px;
+  min-height: 48px;
+  border-radius: 999px;
+  padding: 8px 18px;
+  cursor: pointer;
+  text-align: center;
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease;
+}
+
+.seat.active .player-chip {
+  border-color: rgba(247, 213, 106, 0.76);
+  transform: translateY(-2px);
+}
+
+.player-chip span {
+  font-weight: 750;
+}
+
+.hand-fan {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  min-height: 178px;
+  isolation: isolate;
+}
+
+.seat-west .hand-fan,
+.seat-east .hand-fan {
+  display: grid;
+  grid-template-columns: 1fr;
+  align-content: start;
+  justify-items: center;
+  min-height: 346px;
+}
+
+.personal-piles {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.game-card {
+  --card-width: 142px;
+  --card-height: 222px;
+  position: relative;
+  display: grid;
+  grid-template-rows: auto auto 48px auto minmax(0, 1fr);
+  gap: 5px;
+  width: var(--card-width);
+  height: var(--card-height);
+  padding: 8px;
+  overflow: hidden;
+  border: 1px solid rgba(58, 40, 27, 0.75);
+  border-radius: 7px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(238, 225, 195, 0.9)),
+    #efe0bd;
+  color: #241a13;
+  cursor: pointer;
+  text-align: left;
+  box-shadow:
+    0 12px 22px rgba(0, 0, 0, 0.28),
+    inset 0 0 0 3px rgba(71, 41, 24, 0.12);
+  transform-origin: center bottom;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.game-card.hand {
+  margin-right: -32px;
+  transform: translateY(calc(var(--i) * 2px)) rotate(calc((var(--i) - 2) * 4deg));
+  animation: deal-in 420ms ease both;
+  animation-delay: calc(var(--i) * 45ms);
+}
+
+.seat-west .game-card.hand,
+.seat-east .game-card.hand {
+  --card-width: 132px;
+  --card-height: 204px;
+  margin-right: 0;
+  margin-bottom: -78px;
+  transform: none;
+}
+
+.game-card.table {
+  --card-width: 136px;
+  --card-height: 214px;
+}
+
+.game-card:hover {
+  z-index: 5;
+  border-color: #c99735;
+  box-shadow:
+    0 18px 34px rgba(0, 0, 0, 0.38),
+    0 0 0 3px rgba(231, 191, 85, 0.26);
+}
+
+.game-card.selected {
+  z-index: 5;
+  border-color: #c99735;
+  box-shadow:
+    0 18px 34px rgba(0, 0, 0, 0.38),
+    0 0 0 3px rgba(231, 191, 85, 0.26);
+  transform: translateY(-12px) rotate(0deg) scale(1.04);
+}
+
+.card-kind {
+  font-size: 0.63rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.game-card strong {
+  min-height: 2.05em;
+  overflow-wrap: anywhere;
+  font-family: Georgia, serif;
+  font-size: 0.8rem;
+  line-height: 1.02;
+}
+
+.card-art,
+.mini-art {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  border: 1px solid rgba(63, 42, 25, 0.35);
+  border-radius: 5px;
+  background:
+    radial-gradient(circle at 30% 25%, hsl(var(--tone, 32deg) 78% 72%), transparent 0 22%, transparent 40%),
+    linear-gradient(140deg, hsl(var(--tone, 32deg) 48% 28%), #19251f 62%, #0a1110);
+}
+
+.card-art i,
+.card-art b,
+.card-art em,
+.mini-art i,
+.mini-art b,
+.mini-art em {
+  position: absolute;
+  display: block;
+  content: "";
+}
+
+.card-art i,
+.mini-art i {
+  inset: auto 8% 0;
+  height: 34%;
+  border-radius: 60% 60% 0 0;
+  background: rgba(12, 25, 18, 0.72);
+}
+
+.card-art b,
+.mini-art b {
+  left: 48%;
+  bottom: 20%;
+  width: 12%;
+  height: 52%;
+  border-radius: 999px;
+  background: rgba(245, 222, 160, 0.7);
+  transform: translateX(-50%) rotate(-18deg);
+}
+
+.card-art em,
+.mini-art em {
+  right: 13%;
+  top: 18%;
+  width: 28%;
+  height: 28%;
+  border-radius: 50%;
+  background: rgba(255, 238, 179, 0.54);
+}
+
+.art-shire i,
+.art-forest i,
+.art-council i {
+  background: linear-gradient(90deg, #173c27, #4b7b3a);
+}
+
+.art-mordor,
+.art-wraith,
+.art-beast {
+  background:
+    radial-gradient(circle at 70% 22%, rgba(244, 84, 48, 0.82), transparent 0 17%, transparent 32%),
+    linear-gradient(145deg, #451915, #15100f 65%);
+}
+
+.art-tower b,
+.art-orthanc b,
+.art-wizard b {
+  width: 18%;
+  height: 76%;
+  background: linear-gradient(#d7d0bd, #394148);
+  transform: translateX(-50%);
+}
+
+.art-blade b,
+.art-sword b,
+.art-axe b {
+  width: 9%;
+  height: 78%;
+  background: linear-gradient(#fff7cf, #75818a);
+  transform: translateX(-50%) rotate(42deg);
+}
+
+.art-desert,
+.art-cavern {
+  background:
+    radial-gradient(circle at 30% 22%, rgba(255, 220, 125, 0.75), transparent 0 16%, transparent 36%),
+    linear-gradient(160deg, #8e6335, #2b1f18 66%);
+}
+
+.art-mail {
+  background:
+    radial-gradient(circle, rgba(255, 255, 255, 0.42) 0 2px, transparent 3px) 0 0 / 12px 12px,
+    linear-gradient(145deg, #b9c0bb, #3c4547);
+}
+
+.art-uruk {
+  background:
+    repeating-linear-gradient(90deg, rgba(235, 204, 137, 0.3) 0 4px, transparent 4px 11px),
+    linear-gradient(145deg, #5b211b, #171414);
+}
+
+.card-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 8px;
 }
 
-.metrics span,
-.icons b {
-  border: 1px solid #5d564c;
-  border-radius: 999px;
-  padding: 3px 8px;
-  background: #1b1916;
-  color: #f4efe5;
-  font-size: 0.8rem;
+.card-meta small {
+  color: #5a4631;
+  font-size: 0.66rem;
+  font-weight: 700;
 }
 
-.commands {
-  align-content: start;
+.card-meta mark {
   display: grid;
-  gap: 10px;
+  place-items: center;
+  min-width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #412619;
+  color: #f5dc91;
+  font-size: 0.72rem;
+  font-weight: 800;
 }
 
-.command-grid {
-  grid-template-columns: 1fr;
+.game-card p {
+  display: -webkit-box;
+  overflow: hidden;
+  color: #4e3b2a;
+  font-size: 0.58rem;
+  line-height: 1.14;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 6;
 }
 
-.hand-row {
-  grid-template-columns: minmax(0, 2fr) minmax(180px, 0.7fr) 180px minmax(240px, 1fr);
-  margin-top: 12px;
+.zoom-preview {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+  background: rgba(7, 7, 6, 0.38);
+  animation: zoom-backdrop 140ms ease both;
 }
 
-.zone {
+.zoom-card {
+  display: grid;
+  grid-template-rows: auto auto 190px auto minmax(0, 1fr);
+  gap: 12px;
+  width: min(430px, calc(100vw - 42px));
+  min-height: min(680px, calc(100vh - 42px));
+  padding: 22px;
+  border: 1px solid rgba(58, 40, 27, 0.75);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(238, 225, 195, 0.96)),
+    #efe0bd;
+  color: #241a13;
+  box-shadow:
+    0 34px 90px rgba(0, 0, 0, 0.62),
+    inset 0 0 0 5px rgba(71, 41, 24, 0.12);
+  animation: zoom-card-in 160ms ease both;
+}
+
+.zoom-card .card-kind {
+  font-size: 0.78rem;
+}
+
+.zoom-card strong {
+  font-family: Georgia, serif;
+  font-size: clamp(1.8rem, 4vw, 2.55rem);
+  line-height: 0.98;
+}
+
+.zoom-card .card-art {
   min-height: 190px;
 }
 
-.zone-head {
+.zoom-card .card-meta small {
+  font-size: 0.9rem;
+}
+
+.zoom-card .card-meta mark {
+  min-width: 44px;
+  height: 44px;
+  font-size: 1.08rem;
+}
+
+.zoom-card p {
+  overflow: auto;
+  color: #3c2d21;
+  font-size: clamp(1rem, 2vw, 1.18rem);
+  line-height: 1.36;
+}
+
+.pile {
+  position: relative;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 116px;
+  min-height: 44px;
+  border-radius: 7px;
+  padding: 6px 8px;
+}
+
+.pile span {
+  overflow: hidden;
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pile strong {
+  color: #f5d577;
+}
+
+.stack {
+  position: relative;
+  width: 28px;
+  height: 34px;
+  border-radius: 4px;
+  background: #d8c39a;
+  box-shadow:
+    3px -3px 0 #bca474,
+    6px -6px 0 #8e704c,
+    0 4px 8px rgba(0, 0, 0, 0.28);
+}
+
+.event-log {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 12px;
+  min-height: 0;
+  padding: 14px;
+  border-radius: 8px;
+}
+
+.panel-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 10px;
 }
 
-.zone-head span {
-  color: #d5b36a;
-  font-weight: 700;
+.panel-head span {
+  font-weight: 800;
 }
 
-.card-grid {
+.panel-head strong {
+  color: #f5d577;
+}
+
+.event-log ol {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+  align-content: start;
   gap: 10px;
+  min-height: 0;
+  padding: 0;
+  overflow: auto;
+  list-style: none;
 }
 
-.card {
+.event-log li {
+  padding: 10px 10px 10px 14px;
+  border-left: 3px solid rgba(231, 191, 85, 0.62);
+  border-radius: 0 7px 7px 0;
+  background: rgba(255, 255, 255, 0.045);
+  font-size: 0.88rem;
+  line-height: 1.35;
+  animation: log-in 280ms ease both;
+}
+
+.selection {
   display: grid;
-  grid-template-rows: auto auto auto minmax(54px, 1fr) auto;
-  gap: 6px;
-  min-height: 184px;
-  padding: 10px;
-  text-align: left;
-  background: #211f1b;
+  gap: 8px;
+  border-radius: 8px;
+  padding: 12px;
 }
 
-.card.selected {
-  border-color: #d5b36a;
-  box-shadow: 0 0 0 2px rgba(213, 179, 106, 0.2);
+.inspector-card {
+  display: grid;
+  grid-template-columns: 74px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
 }
 
-.card strong {
-  line-height: 1.15;
+.mini-art {
+  width: 74px;
+  height: 64px;
+  --tone: 38deg;
 }
 
-.card p {
-  color: #d8d0c3;
-  font-size: 0.84rem;
+.inspector-card strong {
+  display: block;
+  margin-bottom: 3px;
+}
+
+.inspector-card p {
+  font-size: 0.8rem;
   line-height: 1.35;
 }
 
-.mini-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  align-content: start;
+@keyframes deal-in {
+  from {
+    opacity: 0;
+    transform: translateY(24px) rotate(0deg) scale(0.92);
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
-.compact-card {
-  border: 1px solid #5d564c;
-  border-radius: 999px;
-  padding: 5px 8px;
-  background: #211f1b;
-  font-size: 0.82rem;
+@keyframes log-in {
+  from {
+    opacity: 0;
+    transform: translateX(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
-.pile-list {
-  display: grid;
-  gap: 8px;
-  margin: 0;
+@keyframes combat-pulse {
+  50% {
+    box-shadow:
+      0 0 0 2px rgba(231, 191, 85, 0.4),
+      0 0 34px rgba(231, 191, 85, 0.36);
+  }
 }
 
-.pile-list div {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
+@keyframes zoom-backdrop {
+  from {
+    opacity: 0;
+  }
 }
 
-.pile-list dt,
-.pile-list dd {
-  margin: 0;
+@keyframes zoom-card-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.96);
+  }
 }
 
-.pile-list dt {
-  color: #c8bdab;
-}
-
-.log ol {
-  display: grid;
-  max-height: 220px;
-  gap: 8px;
-  margin: 0;
-  padding-left: 20px;
-  overflow: auto;
-  color: #d8d0c3;
-  font-size: 0.86rem;
-}
-
-@media (max-width: 1040px) {
-  .topbar,
-  .board,
-  .hand-row {
+@media (max-width: 1280px) {
+  .table-layout {
     grid-template-columns: 1fr;
   }
 
-  .toolbar {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
-  .table {
-    grid-template-columns: 1fr;
-  }
-
-  .players {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .event-log {
+    min-height: 280px;
   }
 }
 
-@media (max-width: 600px) {
-  .shell {
+@media (max-width: 980px) {
+  .hud {
+    grid-template-columns: 1fr;
+  }
+
+  .score-track,
+  .actions {
+    grid-auto-flow: row;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .score-track {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .table-stage {
+    display: grid;
+    grid-template: none;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
+    min-height: 0;
+    overflow: visible;
+    background: transparent;
+  }
+
+  .felt-table,
+  .seat,
+  .seat-north,
+  .seat-south,
+  .seat-west,
+  .seat-east {
+    grid-area: auto;
+    position: static;
+    width: auto;
+    transform: none;
+  }
+
+  .felt-table {
+    order: 2;
+    grid-area: auto;
+    grid-template-columns: 1fr;
+    min-height: 0;
+    border-radius: 18px;
+  }
+
+  .seat {
+    justify-items: stretch;
+    min-width: 0;
+    border-radius: 8px;
+    padding: 10px;
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .seat-west .hand-fan,
+  .seat-east .hand-fan {
+    display: flex;
+    min-height: 178px;
+  }
+
+  .seat-north {
+    order: 1;
+  }
+
+  .seat-east,
+  .seat-west,
+  .seat-south {
+    order: 3;
+  }
+
+  .hand-fan {
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding-bottom: 12px;
+  }
+
+  .game-card.hand {
+    flex: 0 0 auto;
+    margin-right: 8px;
+    transform: none;
+  }
+
+  .seat-west .game-card.hand,
+  .seat-east .game-card.hand {
+    --card-width: 112px;
+    --card-height: 158px;
+    margin-bottom: 0;
+  }
+
+  .personal-piles {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 640px) {
+  .game-shell {
     padding: 10px;
   }
 
-  .brand {
+  .identity {
     align-items: flex-start;
   }
 
-  .brand img {
+  .sigil {
     width: 44px;
     height: 44px;
   }
 
-  .players,
-  .scoreboard,
-  .toolbar {
-    grid-template-columns: 1fr;
+  .score-track,
+  .actions {
+    grid-auto-flow: row;
+    grid-template-columns: 1fr 1fr;
   }
 
-  .card-grid {
+  .felt-table {
+    padding: 18px;
+    border-width: 10px;
+  }
+
+  .center-zone {
+    padding: 12px;
+  }
+
+  .game-card,
+  .game-card.table {
+    --card-width: 112px;
+    --card-height: 158px;
+  }
+
+  .table-piles,
+  .personal-piles {
+    display: grid;
     grid-template-columns: 1fr;
   }
 }

--- a/tests/e2e/table-ui.spec.ts
+++ b/tests/e2e/table-ui.spec.ts
@@ -1,56 +1,66 @@
 import { expect, test } from "@playwright/test";
 
-test.describe("standalone table UI", () => {
+test.describe("real game table UI", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
   });
 
-  test("renders the four-player table with real location text", async ({ page }) => {
+  test("renders real engine state at the four-player table", async ({ page }) => {
     await expect(page.getByRole("heading", { name: "War of the Ring" })).toBeVisible();
+    await expect(page.getByText("Round 1 - Action - seed middle-earth")).toBeVisible();
 
-    await expect(page.getByLabel("Aragorn seat")).toContainText("Free Peoples - 5 cards");
-    await expect(page.getByLabel("Witch-king seat")).toContainText("Shadow - 5 cards");
-    await expect(page.getByLabel("Frodo seat")).toContainText("Free Peoples - 6 cards");
-    await expect(page.getByLabel("Saruman seat")).toContainText("Shadow - 7 cards");
+    await expect(page.getByLabel("Aragorn seat")).toContainText("Free Peoples -");
+    await expect(page.getByLabel("Witch-king seat")).toContainText("Shadow -");
+    await expect(page.getByLabel("Frodo seat")).toContainText("Free Peoples -");
+    await expect(page.getByLabel("Saruman seat")).toContainText("Shadow -");
 
     const table = page.getByLabel("Play area");
-    await expect(table.getByText("Minas Tirith", { exact: true })).toBeVisible();
-    await expect(
-      page.getByText("Dunedain player MAY forsake 1 card to draw 3 cards."),
-    ).toBeVisible();
-    await expect(table.getByText("Cirith Ungol", { exact: true })).toBeVisible();
-    await expect(
-      page.getByText("The Mordor player draws 5 cards, may play 1 Army and cycles rest."),
-    ).toBeVisible();
+    await expect(table.locator(".battleground-zone .zone-title span")).toHaveText(
+      "Battleground",
+    );
+    await expect(table.locator(".path-zone .zone-title span")).toHaveText("Path");
+    await expect(table.locator(".battleground-zone .zone-title small")).toContainText(
+      "Defense",
+    );
+    await expect(table.locator(".battleground-zone .zone-title small")).toContainText(
+      "VP",
+    );
+    await expect(table.locator(".game-card.table")).toHaveCount(0);
   });
 
-  test("selects a card and updates the selected-card inspector", async ({ page }) => {
-    await page.locator("[data-card-id='black-captain']").click();
+  test("selects a real card and updates the selected-card inspector", async ({ page }) => {
+    const firstHandCard = page.locator(".game-card.hand").first();
+    await expect(firstHandCard).toBeVisible();
+
+    const title = await firstHandCard.locator("strong").innerText();
+    await firstHandCard.click();
 
     const selection = page.getByLabel("Event log").locator(".selection");
-    await expect(selection).toContainText("The Black Captain");
-    await expect(selection).toContainText("(re)activate any Mordor battleground");
-    await expect(page.getByLabel("Witch-king seat")).toHaveClass(/active/);
+    await expect(selection).toContainText(title);
+    await expect(selection).not.toContainText("No card selected");
   });
 
-  test("logs mock actions without leaving the page", async ({ page }) => {
-    await page.getByRole("button", { name: "Resolve" }).click();
+  test("executes a real engine action and appends the game log", async ({ page }) => {
+    await page.locator("[data-action='ring']").click();
 
     await expect(page.getByLabel("Event log")).toContainText(
-      "Combat resolves at Minas Tirith; committed cards pulse on the felt.",
+      "Frodo used a ring token and drew 2 cards.",
     );
     await expect(page).toHaveURL(/\/wotr-card-game-python\/$/);
   });
 
-  test("shows a stable long-hover card preview with full text", async ({ page }) => {
-    await page.locator("[data-card-id='black-captain']").hover();
-    const preview = page.getByLabel("Card preview");
+  test("shows a stable long-hover preview for a real card", async ({ page }) => {
+    const firstHandCard = page.locator(".game-card.hand").first();
+    await expect(firstHandCard).toBeVisible();
 
+    const title = await firstHandCard.locator("strong").innerText();
+    const rulesText = await firstHandCard.locator("p").innerText();
+    await firstHandCard.hover();
+
+    const preview = page.getByLabel("Card preview");
     await expect(preview).toBeVisible();
-    await expect(preview).toContainText("The Black Captain");
-    await expect(preview).toContainText(
-      "If the Witch-King is in reserve (active or not), (re)activate any Mordor battleground, then you MAY move the Witch-King to this battleground.",
-    );
+    await expect(preview).toContainText(title);
+    await expect(preview).toContainText(rulesText);
 
     await page.waitForTimeout(1_500);
     await expect(preview).toHaveCount(1);
@@ -59,15 +69,13 @@ test.describe("standalone table UI", () => {
     await expect(preview).toHaveCount(0);
   });
 
-  test("keeps the mobile layout usable", async ({ page }) => {
+  test("keeps the real game usable on mobile", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 900 });
     await page.goto("/");
 
     await expect(page.getByLabel("Aragorn seat")).toBeVisible();
-    await expect(page.getByText("Anduril")).toBeVisible();
-    await expect(
-      page.getByLabel("Play area").getByText("Minas Tirith", { exact: true }),
-    ).toBeVisible();
+    await expect(page.getByLabel("Play area")).toBeVisible();
+    await expect(page.locator(".game-card.hand").first()).toBeVisible();
     await expect(page.getByRole("button", { name: "Resolve" })).toBeVisible();
   });
 });

--- a/tests/e2e/table-ui.spec.ts
+++ b/tests/e2e/table-ui.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("standalone table UI", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("renders the four-player table with real location text", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: "War of the Ring" })).toBeVisible();
+
+    await expect(page.getByLabel("Aragorn seat")).toContainText("Free Peoples - 5 cards");
+    await expect(page.getByLabel("Witch-king seat")).toContainText("Shadow - 5 cards");
+    await expect(page.getByLabel("Frodo seat")).toContainText("Free Peoples - 6 cards");
+    await expect(page.getByLabel("Saruman seat")).toContainText("Shadow - 7 cards");
+
+    const table = page.getByLabel("Play area");
+    await expect(table.getByText("Minas Tirith", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Dunedain player MAY forsake 1 card to draw 3 cards."),
+    ).toBeVisible();
+    await expect(table.getByText("Cirith Ungol", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("The Mordor player draws 5 cards, may play 1 Army and cycles rest."),
+    ).toBeVisible();
+  });
+
+  test("selects a card and updates the selected-card inspector", async ({ page }) => {
+    await page.locator("[data-card-id='black-captain']").click();
+
+    const selection = page.getByLabel("Event log").locator(".selection");
+    await expect(selection).toContainText("The Black Captain");
+    await expect(selection).toContainText("(re)activate any Mordor battleground");
+    await expect(page.getByLabel("Witch-king seat")).toHaveClass(/active/);
+  });
+
+  test("logs mock actions without leaving the page", async ({ page }) => {
+    await page.getByRole("button", { name: "Resolve" }).click();
+
+    await expect(page.getByLabel("Event log")).toContainText(
+      "Combat resolves at Minas Tirith; committed cards pulse on the felt.",
+    );
+    await expect(page).toHaveURL(/\/wotr-card-game-python\/$/);
+  });
+
+  test("shows a stable long-hover card preview with full text", async ({ page }) => {
+    await page.locator("[data-card-id='black-captain']").hover();
+    const preview = page.getByLabel("Card preview");
+
+    await expect(preview).toBeVisible();
+    await expect(preview).toContainText("The Black Captain");
+    await expect(preview).toContainText(
+      "If the Witch-King is in reserve (active or not), (re)activate any Mordor battleground, then you MAY move the Witch-King to this battleground.",
+    );
+
+    await page.waitForTimeout(1_500);
+    await expect(preview).toHaveCount(1);
+
+    await page.mouse.move(12, 12);
+    await expect(preview).toHaveCount(0);
+  });
+
+  test("keeps the mobile layout usable", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 900 });
+    await page.goto("/");
+
+    await expect(page.getByLabel("Aragorn seat")).toBeVisible();
+    await expect(page.getByText("Anduril")).toBeVisible();
+    await expect(
+      page.getByLabel("Play area").getByText("Minas Tirith", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Resolve" })).toBeVisible();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,8 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   base: "/wotr-card-game-python/",
+  test: {
+    exclude: ["tests/e2e/**", "node_modules/**", "dist/**"],
+  },
 });


### PR DESCRIPTION
## Summary
- reapplies the approved standalone table UI on top of current master after the previous UI merge/revert
- keeps the frontend mock decoupled from the engine/rules kernel while preserving the table, card text, path/battleground text, event log, piles, animations, and stable long-hover card preview
- leaves the rules-kernel changes from master intact; this PR only changes src/main.ts and src/styles.css relative to current master

## Verification
- npm run typecheck
- npm run build
- npm test