### PR TITLE
Add backend edge-case invariants and fuzz coverage

### DIFF
--- a/src/archive.ts
+++ b/src/archive.ts
@@ -18,7 +18,7 @@ import {
 import type { ForsakeSource, GameState, PlayerId, PlayDestination } from "./types";
 
 export const archiveVersion = 1;
-export const engineVersion = "engine-command-journal-v2";
+export const engineVersion = "engine-command-journal-v3";
 export const rulesReferenceVersion = "rules-v1.1-cards-v0.2";
 export const rngVersion = "fnv1a-seed-mulberry32-v1";
 

--- a/src/edgeCaseRegistry.ts
+++ b/src/edgeCaseRegistry.ts
@@ -1,0 +1,162 @@
+export type EdgeCaseStatus = "implemented" | "scaffolded" | "blocked";
+
+export interface EdgeCaseRecord {
+  readonly id: string;
+  readonly category:
+    | "archive"
+    | "attachment"
+    | "bgg"
+    | "card"
+    | "combat"
+    | "fuzz"
+    | "invariant"
+    | "location"
+    | "rules"
+    | "scenario";
+  readonly title: string;
+  readonly status: EdgeCaseStatus;
+  readonly sources: readonly string[];
+}
+
+export const edgeCaseRegistry: readonly EdgeCaseRecord[] = [
+  {
+    id: "rules-last-card-forsake",
+    category: "rules",
+    title: "Playing the last hand card falls back to forsake.",
+    status: "implemented",
+    sources: ["rules:151-158", "bgg:2954283"],
+  },
+  {
+    id: "rules-forsake-choice",
+    category: "rules",
+    title: "Forsake can choose hand, reserve, or top of draw deck.",
+    status: "implemented",
+    sources: ["rules:385-395"],
+  },
+  {
+    id: "rules-pass-legality",
+    category: "rules",
+    title: "Pass is legal only by carryover or enemy-hand condition.",
+    status: "implemented",
+    sources: ["rules:142-145", "bgg:2979005", "bgg:3214050"],
+  },
+  {
+    id: "rules-winnow-hand-only",
+    category: "rules",
+    title: "Winnow eliminates exactly two different hand cards to draw one.",
+    status: "implemented",
+    sources: ["rules:138", "rules:242", "bgg:3061596", "bgg:3026810"],
+  },
+  {
+    id: "attachment-item-wielder",
+    category: "attachment",
+    title: "Items attach only to indicated in-play character wielders.",
+    status: "implemented",
+    sources: ["rules:173-177", "bgg:2951361", "bgg:3114689"],
+  },
+  {
+    id: "attachment-leaves-with-wielder",
+    category: "attachment",
+    title: "Attached items leave play with the wielder.",
+    status: "implemented",
+    sources: ["rules:178-186"],
+  },
+  {
+    id: "location-activated-path-history",
+    category: "location",
+    title: "Specific paths cannot be activated more than once per game.",
+    status: "scaffolded",
+    sources: ["rules:116-121", "bgg:3021148", "bgg:3121693"],
+  },
+  {
+    id: "location-scoring-areas",
+    category: "location",
+    title: "Scored paths and battlegrounds are tracked by side.",
+    status: "scaffolded",
+    sources: ["rules:420-444", "bgg:3036614", "bgg:3060247"],
+  },
+  {
+    id: "combat-corruption-path",
+    category: "combat",
+    title: "Shadow path success records corruption and facedown path scoring.",
+    status: "scaffolded",
+    sources: ["rules:286-293", "rules:426-440", "bgg:3074641", "bgg:3246013"],
+  },
+  {
+    id: "combat-support-assignment",
+    category: "combat",
+    title: "Leadership icons require same-faction army support and support assignment choices.",
+    status: "blocked",
+    sources: ["rules:325-338", "bgg:3193261", "bgg:3224992"],
+  },
+  {
+    id: "combat-loss-pending-decision",
+    category: "combat",
+    title: "Defender loss assignment must be a pending decision when ambiguous.",
+    status: "scaffolded",
+    sources: ["rules:270-285", "rules:310-320"],
+  },
+  {
+    id: "location-reactivate-battleground",
+    category: "location",
+    title: "Reactivation takes battleground from scoring area and can ignore defense.",
+    status: "blocked",
+    sources: ["rules:99-101", "rules:302-304", "bgg:3017468", "bgg:3107840"],
+  },
+  {
+    id: "card-draw-play-cycle-rest",
+    category: "card",
+    title: "Draw N, play up to M, cycle rest can satisfy play costs.",
+    status: "blocked",
+    sources: ["rules:213-216", "bgg:3402025", "bgg:3716703"],
+  },
+  {
+    id: "card-replacement-effects",
+    category: "card",
+    title: "Cycle-instead-of-eliminate/forsake replacement effects.",
+    status: "blocked",
+    sources: ["cards:69", "cards:73", "cards:89", "cards:107", "cards:144"],
+  },
+  {
+    id: "scenario-ring-rules",
+    category: "scenario",
+    title: "Ring token rules vary by scenario.",
+    status: "blocked",
+    sources: ["rules:744-747", "rules:765-769", "rules:798-801"],
+  },
+  {
+    id: "invariant-card-location",
+    category: "invariant",
+    title: "Every card has exactly one physical location.",
+    status: "implemented",
+    sources: ["docs:rules-edge-case-plan"],
+  },
+  {
+    id: "fuzz-seeded-command-stream",
+    category: "fuzz",
+    title: "Seeded generated command streams preserve invariants.",
+    status: "implemented",
+    sources: ["docs:rules-edge-case-plan"],
+  },
+  {
+    id: "archive-drift-detection",
+    category: "archive",
+    title: "Archive replay catches command and metadata drift.",
+    status: "implemented",
+    sources: ["src/archive.test.ts"],
+  },
+  {
+    id: "bgg-items-reserve",
+    category: "bgg",
+    title: "Items, reserve, movement, and active character ambiguity.",
+    status: "scaffolded",
+    sources: ["bgg:3023399", "bgg:3052983", "bgg:3718707"],
+  },
+  {
+    id: "bgg-no-card-combat",
+    category: "bgg",
+    title: "Combat with no cards or uncontested cards needs oracle fixture.",
+    status: "blocked",
+    sources: ["bgg:2968253", "bgg:3036060", "bgg:3148051"],
+  },
+];

--- a/src/effectClassification.test.ts
+++ b/src/effectClassification.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { battlegroundDefinitions, cardDefinitions, pathDefinitions } from "./data";
+import { effectClassifications } from "./effectClassification";
+
+describe("effect classification", () => {
+  it("classifies every card, path, and battleground reference", () => {
+    expect(effectClassifications).toHaveLength(
+      cardDefinitions.length + pathDefinitions.length + battlegroundDefinitions.length,
+    );
+    expect(effectClassifications.every((entry) => entry.sourceLine > 0)).toBe(true);
+  });
+
+  it.each([
+    ["draw"],
+    ["cycle"],
+    ["forsake"],
+    ["eliminate"],
+    ["search"],
+    ["reserve-action"],
+    ["activate-battleground"],
+    ["activate-path"],
+    ["move"],
+    ["token"],
+    ["corruption"],
+    ["replacement"],
+    ["when-played"],
+    ["when-played-or-moved"],
+    ["draw-play-cycle-rest"],
+  ] as const)("has at least one %s effect to drive backend fixtures", (tag) => {
+    expect(effectClassifications.some((entry) => entry.tags.includes(tag))).toBe(true);
+  });
+
+  it("identifies known high-risk card templates", () => {
+    expect(tagsFor("balrog-118")).toContain("when-played-or-moved");
+    expect(tagsFor("shadowfax-86")).toEqual(
+      expect.arrayContaining(["attach-item", "activate-battleground", "move", "reserve-action"]),
+    );
+    expect(tagsFor("the-ringwraiths-are-abroad-164")).toContain("draw-play-cycle-rest");
+    expect(tagsFor("frodo-baggins-69")).toContain("replacement");
+  });
+});
+
+function tagsFor(id: string): readonly string[] {
+  const entry = effectClassifications.find((candidate) => candidate.id === id);
+  if (entry === undefined) {
+    throw new Error(`Missing classification for ${id}`);
+  }
+  return entry.tags;
+}

--- a/src/effectClassification.ts
+++ b/src/effectClassification.ts
@@ -1,0 +1,112 @@
+import { battlegroundDefinitions, cardDefinitions, pathDefinitions } from "./data";
+
+export type EffectTag =
+  | "activate-battleground"
+  | "activate-path"
+  | "attach-item"
+  | "carryover"
+  | "corruption"
+  | "cycle"
+  | "draw"
+  | "draw-play-cycle-rest"
+  | "eliminate"
+  | "forsake"
+  | "move"
+  | "replacement"
+  | "reserve-action"
+  | "search"
+  | "token"
+  | "when-played"
+  | "when-played-or-moved";
+
+export interface EffectClassification {
+  readonly id: string;
+  readonly kind: "card" | "path" | "battleground";
+  readonly title: string;
+  readonly text: string;
+  readonly tags: readonly EffectTag[];
+  readonly sourceLine: number;
+}
+
+export const effectClassifications: readonly EffectClassification[] = [
+  ...cardDefinitions.map((card) => ({
+    id: card.id,
+    kind: "card" as const,
+    title: card.title,
+    text: card.text,
+    tags: classifyEffectText(card.text, card.type === "item"),
+    sourceLine: card.sourceLine,
+  })),
+  ...pathDefinitions.map((path) => ({
+    id: path.id,
+    kind: "path" as const,
+    title: path.title,
+    text: path.text,
+    tags: classifyEffectText(path.text, false),
+    sourceLine: path.sourceLine,
+  })),
+  ...battlegroundDefinitions.map((battleground) => ({
+    id: battleground.id,
+    kind: "battleground" as const,
+    title: battleground.title,
+    text: battleground.text,
+    tags: classifyEffectText(battleground.text, false),
+    sourceLine: battleground.sourceLine,
+  })),
+];
+
+export function classifyEffectText(text: string, isItem: boolean): readonly EffectTag[] {
+  const normalized = text.toLowerCase();
+  const tags = new Set<EffectTag>();
+  if (isItem) {
+    tags.add("attach-item");
+  }
+  if (/\bdraw(s| \d|\+| each| top)?\b/.test(normalized)) {
+    tags.add("draw");
+  }
+  if (normalized.includes("cycle")) {
+    tags.add("cycle");
+  }
+  if (normalized.includes("forsake")) {
+    tags.add("forsake");
+  }
+  if (normalized.includes("eliminate") || normalized.includes("remove")) {
+    tags.add("eliminate");
+  }
+  if (normalized.includes("take ") || normalized.includes("from your draw deck")) {
+    tags.add("search");
+  }
+  if (normalized.includes("reserve")) {
+    tags.add("reserve-action");
+  }
+  if (normalized.includes("activate") && normalized.includes("battleground")) {
+    tags.add("activate-battleground");
+  }
+  if (normalized.includes("activate") && normalized.includes("path")) {
+    tags.add("activate-path");
+  }
+  if (normalized.includes("move")) {
+    tags.add("move");
+  }
+  if (normalized.includes("token") || normalized.includes("marker")) {
+    tags.add("token");
+  }
+  if (normalized.includes("corruption")) {
+    tags.add("corruption");
+  }
+  if (normalized.includes("carryover") || normalized.includes("col")) {
+    tags.add("carryover");
+  }
+  if (normalized.includes("cycle instead")) {
+    tags.add("replacement");
+  }
+  if (normalized.includes("when played or moved")) {
+    tags.add("when-played-or-moved");
+  } else if (normalized.includes("when played")) {
+    tags.add("when-played");
+  }
+  if (normalized.includes("draw 5") || normalized.includes("draw 7") || normalized.includes("cycle the rest")) {
+    tags.add("draw-play-cycle-rest");
+  }
+  return [...tags].sort();
+}

--- a/src/game.ts
+++ b/src/game.ts
@@ -13,8 +13,10 @@ import type {
   CommandResult,
   ForsakeSource,
   Faction,
+  GameEvent,
   GameState,
   Phase,
+  PendingDecision,
   PlayDestination,
   PlayerId,
   PlayerState,
@@ -114,12 +116,20 @@ export function createGame(seed = String(Date.now())): GameState {
       ),
     },
     pathDeck: pathDefinitions.map((path) => path.id),
+    activatedPaths: [],
     activeBattleground: null,
     activePath: null,
     players: playerStates,
     cards: instances,
     attachments: {},
     roundMemory: { playedToReserve: [], playedCharacterOrItemCards: [] },
+    pendingDecisions: [],
+    eventLog: [],
+    scoringAreas: {
+      battlegrounds: { free: [], shadow: [] },
+      paths: { free: [], shadow: [] },
+    },
+    corruption: { tokens: 0 },
     score: { free: 0, shadow: 0 },
     log: [],
     selection: { playerId: "frodo", cardId: null },
@@ -186,7 +196,9 @@ export function tryPlayCard(
     });
   }
   const nextState = playCard(state, playerId, instanceId, destination, costCardId);
-  return accepted(nextState, [`played:${instanceId}:${destination}`]);
+  return accepted(nextState, [
+    { type: "cardPlayed", playerId, cardId: instanceId, destination },
+  ]);
 }
 
 export function playCard(
@@ -322,7 +334,9 @@ export function tryAttachItem(
   }
 
   const nextState = attachItem(state, playerId, itemId, wielderId, costCardId);
-  return accepted(nextState, [`attached:${itemId}:${wielderId}`]);
+  return accepted(nextState, [
+    { type: "itemAttached", playerId, itemId, wielderId },
+  ]);
 }
 
 export function attachItem(
@@ -436,7 +450,7 @@ export function tryPass(state: GameState): CommandResult {
       source: "rules:142-145",
     });
   }
-  return accepted(pass(state), [`passed:${playerId}`]);
+  return accepted(pass(state), [{ type: "playerPassed", playerId }]);
 }
 
 export function pass(state: GameState): GameState {
@@ -503,7 +517,7 @@ export function tryMoveFromReserve(
     });
   }
   return accepted(moveFromReserve(state, playerId, instanceId, destination), [
-    `moved:${instanceId}:${destination}`,
+    { type: "cardMoved", playerId, cardId: instanceId, destination },
   ]);
 }
 
@@ -572,7 +586,7 @@ export function tryWinnow(
     });
   }
   return accepted(winnow(state, playerId, firstCardId, secondCardId), [
-    `winnowed:${firstCardId}:${secondCardId}`,
+    { type: "winnowed", playerId, cards: [firstCardId, secondCardId] },
   ]);
 }
 
@@ -604,7 +618,11 @@ export function tryForsake(
       source: "rules:385-395",
     });
   }
-  return accepted(nextState, [`forsook:${source}:${instanceId ?? "top"}`]);
+  return accepted(nextState, [
+    instanceId === undefined
+      ? { type: "cardForsaken", playerId, source }
+      : { type: "cardForsaken", playerId, source, cardId: instanceId },
+  ]);
 }
 
 export function forsakeCard(
@@ -627,6 +645,102 @@ export function forsakeCard(
     return eliminateCards(state, [instanceId]);
   }
   return null;
+}
+
+export function addCorruption(state: GameState, count: number): GameState {
+  if (count <= 0) {
+    return state;
+  }
+  return {
+    ...state,
+    corruption: { tokens: state.corruption.tokens + count },
+    score: { ...state.score, shadow: state.score.shadow + count },
+  };
+}
+
+export function removeCorruption(state: GameState, count: number): GameState {
+  if (count <= 0) {
+    return state;
+  }
+  const removed = Math.min(count, state.corruption.tokens);
+  return {
+    ...state,
+    corruption: { tokens: state.corruption.tokens - removed },
+    score: { ...state.score, shadow: Math.max(0, state.score.shadow - removed) },
+  };
+}
+
+export function addActivePathAttackTokens(state: GameState, count: number): GameState {
+  if (count <= 0 || state.activePath === null) {
+    return state;
+  }
+  return {
+    ...state,
+    activePath: {
+      ...state.activePath,
+      attackTokens: state.activePath.attackTokens + count,
+    },
+  };
+}
+
+export function addActivePathDefenseTokens(state: GameState, count: number): GameState {
+  if (count <= 0 || state.activePath === null) {
+    return state;
+  }
+  return {
+    ...state,
+    activePath: {
+      ...state.activePath,
+      defenseTokens: state.activePath.defenseTokens + count,
+    },
+  };
+}
+
+export function activatePathById(state: GameState, pathId: string): GameState | null {
+  const path = pathById.get(pathId);
+  if (path === undefined || state.activatedPaths.includes(pathId)) {
+    return null;
+  }
+  let nextState = state.activePath === null ? state : scorePath(state, state.activePath);
+  nextState = removeScoredActivePathCards(nextState);
+  return addLog(
+    {
+      ...nextState,
+      activePath: { id: pathId, cards: [], attackTokens: 0, defenseTokens: 0 },
+      pathDeck: nextState.pathDeck.filter((id) => id !== pathId),
+      activatedPaths: [...nextState.activatedPaths, pathId],
+    },
+    `Activated ${path.title}.`,
+  );
+}
+
+export function eligiblePathsByNumber(
+  state: GameState,
+  pathNumber: number,
+): readonly string[] {
+  return pathDefinitions
+    .filter((path) => path.pathNumber === pathNumber)
+    .map((path) => path.id)
+    .filter((pathId) => !state.activatedPaths.includes(pathId));
+}
+
+export function enqueuePendingDecision(
+  state: GameState,
+  decision: PendingDecision,
+): GameState {
+  return {
+    ...state,
+    pendingDecisions: [...state.pendingDecisions, decision],
+    eventLog: [
+      ...state.eventLog,
+      { type: "pendingDecisionCreated", decision },
+    ],
+  };
+}
+
+export function resolveOldestPendingDecision(state: GameState): GameState {
+  const [, ...remaining] = state.pendingDecisions;
+  return { ...state, pendingDecisions: remaining };
 }
 
 export function nextTurn(state: GameState): GameState {
@@ -866,6 +980,8 @@ function startRound(state: GameState): GameState {
       : ({
           id: nextPathId,
           cards: [],
+          attackTokens: 0,
+          defenseTokens: 0,
         } satisfies ActivePath);
 
   const nextPathDeck =
@@ -883,6 +999,10 @@ function startRound(state: GameState): GameState {
         [side]: remainingBattlegrounds,
       },
       pathDeck: nextPathDeck,
+      activatedPaths:
+        nextPathId === null || state.activatedPaths.includes(nextPathId)
+          ? state.activatedPaths
+          : [...state.activatedPaths, nextPathId],
       activeBattleground: nextBattleground,
       activePath: nextPath,
       roundMemory: { playedToReserve: [], playedCharacterOrItemCards: [] },
@@ -932,6 +1052,16 @@ function scoreBattleground(
             ...state.score,
             [winner]: state.score[winner] + definition.victoryPoints,
           },
+          scoringAreas: {
+            ...state.scoringAreas,
+            battlegrounds: {
+              ...state.scoringAreas.battlegrounds,
+              [winner]: uniqueAppend(
+                state.scoringAreas.battlegrounds[winner],
+                definition.id,
+              ),
+            },
+          },
         },
         [...attackingCards, ...defenderLosses],
       ),
@@ -948,10 +1078,10 @@ function scorePath(state: GameState, path: ActivePath): GameState {
   }
   const shadowCards = path.cards.filter((instanceId) => cardSide(state, instanceId) === "shadow");
   const freeCards = path.cards.filter((instanceId) => cardSide(state, instanceId) === "free");
-  const attack = shadowCards
+  const attack = path.attackTokens + shadowCards
     .map((instanceId) => getCardDefinition(getCard(state, instanceId).cardId))
     .reduce((sum, card) => sum + card.pathIcons, 0);
-  const locationDefense = definition.defenseIcons;
+  const locationDefense = definition.defenseIcons + path.defenseTokens;
   const remainingAttack = Math.max(0, attack - locationDefense);
   const freeDefense = freeCards
     .map((instanceId) => getCardDefinition(getCard(state, instanceId).cardId))
@@ -961,15 +1091,30 @@ function scorePath(state: GameState, path: ActivePath): GameState {
   const { eliminated: defenderLosses, cycled: defenderSurvivors } =
     assignDefenderLosses(state, freeCards, remainingAttack, "path");
   const points = winner === "free" ? definition.victoryPoints : uncanceledAttack;
+  const corruptionAdded = winner === "shadow" ? uncanceledAttack : 0;
 
   return addLog(
     cycleCards(
       eliminateCards(
         {
           ...state,
+          corruption: {
+            tokens: state.corruption.tokens + corruptionAdded,
+          },
           score: {
             ...state.score,
             [winner]: state.score[winner] + points,
+          },
+          scoringAreas: {
+            ...state.scoringAreas,
+            paths: {
+              ...state.scoringAreas.paths,
+              [winner]: appendScoredPath(state.scoringAreas.paths[winner], {
+                id: definition.id,
+                points,
+                facedown: winner === "shadow",
+              }),
+            },
           },
         },
         [...shadowCards, ...defenderLosses],
@@ -1148,6 +1293,19 @@ function removeFromSharedPlayZones(state: GameState, instanceId: string): GameSt
   };
 }
 
+function removeScoredActivePathCards(state: GameState): GameState {
+  if (state.activePath === null) {
+    return state;
+  }
+  return {
+    ...state,
+    activePath: {
+      ...state.activePath,
+      cards: [],
+    },
+  };
+}
+
 function rememberCharacterOrItemPlayed(state: GameState, cardId: string): GameState {
   if (state.roundMemory.playedCharacterOrItemCards.includes(cardId)) {
     return state;
@@ -1225,12 +1383,19 @@ function validateActionTurn(state: GameState, playerId: PlayerId): RuleViolation
   return null;
 }
 
-function accepted(state: GameState, events: readonly string[]): CommandResult {
-  return { ok: true, state, events };
+function accepted(state: GameState, events: readonly GameEvent[]): CommandResult {
+  return { ok: true, state: appendEvents(state, events), events };
 }
 
 function rejected(state: GameState, violation: RuleViolation): CommandResult {
   return { ok: false, state, violation };
+}
+
+function appendEvents(state: GameState, events: readonly GameEvent[]): GameState {
+  if (events.length === 0) {
+    return state;
+  }
+  return { ...state, eventLog: [...state.eventLog, ...events] };
 }
 
 function normalizeName(value: string): string {
@@ -1347,6 +1512,17 @@ function removeOne(items: readonly string[], item: string): readonly string[] {
     return items;
   }
   return [...items.slice(0, index), ...items.slice(index + 1)];
+}
+
+function uniqueAppend(items: readonly string[], item: string): readonly string[] {
+  return items.includes(item) ? items : [...items, item];
+}
+
+function appendScoredPath(
+  paths: GameState["scoringAreas"]["paths"][Side],
+  path: GameState["scoringAreas"]["paths"][Side][number],
+): GameState["scoringAreas"]["paths"][Side] {
+  return paths.some((existing) => existing.id === path.id) ? paths : [...paths, path];
 }
 
 function nextPlayerId(playerId: PlayerId): PlayerId {

--- a/src/gameScripts.ts
+++ b/src/gameScripts.ts
@@ -47,6 +47,8 @@ export interface CompactArrangement {
 export interface CompactActivePath {
   readonly id: string;
   readonly cards?: readonly string[];
+  readonly attackTokens?: number;
+  readonly defenseTokens?: number;
 }
 
 export interface CompactActiveBattleground {
@@ -292,6 +294,8 @@ function resolveActivePath(
   return {
     id: activePath.id,
     cards: activePath.cards?.map((card) => resolveAnyCardRef(state, card)) ?? [],
+    attackTokens: activePath.attackTokens ?? 0,
+    defenseTokens: activePath.defenseTokens ?? 0,
   };
 }
 

--- a/src/invariants.test.ts
+++ b/src/invariants.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+
+import { edgeCaseRegistry } from "./edgeCaseRegistry";
+import {
+  activatePathById,
+  addActivePathAttackTokens,
+  addActivePathDefenseTokens,
+  addCorruption,
+  canPlayTo,
+  createGame,
+  cycleCard,
+  eligiblePathsByNumber,
+  enqueuePendingDecision,
+  nextTurn,
+  removeCorruption,
+  resolveOldestPendingDecision,
+  resolveCombat,
+  tryMoveFromReserve,
+  tryPass,
+  tryPlayCard,
+  tryWinnow,
+  usePlayerRingToken,
+} from "./game";
+import { assertGameInvariants } from "./invariants";
+import type { CommandResult, GameState, PlayerId } from "./types";
+
+describe("engine invariants", () => {
+  it.each(Array.from({ length: 80 }, (_, index) => `invariant-seed-${index + 1}`))(
+    "holds after setup for %s",
+    (seed) => {
+      expect(assertGameInvariants(createGame(seed))).toEqual([]);
+    },
+  );
+
+  it("records every edge-case registry entry with category, status, and source", () => {
+    expect(edgeCaseRegistry.length).toBeGreaterThanOrEqual(20);
+    expect(new Set(edgeCaseRegistry.map((entry) => entry.id)).size).toBe(
+      edgeCaseRegistry.length,
+    );
+    expect(edgeCaseRegistry.every((entry) => entry.sources.length > 0)).toBe(true);
+    expect(edgeCaseRegistry.some((entry) => entry.status === "blocked")).toBe(true);
+    expect(edgeCaseRegistry.some((entry) => entry.status === "implemented")).toBe(true);
+    expect(edgeCaseRegistry.some((entry) => entry.category === "bgg")).toBe(true);
+  });
+
+  it.each(Array.from({ length: 40 }, (_, index) => `fuzz-seed-${index + 1}`))(
+    "preserves invariants through seeded generated commands: %s",
+    (seed) => {
+      let state = createGame(seed);
+      const rng = seededRng(seed);
+
+      for (let step = 0; step < 80; step += 1) {
+        const before = JSON.stringify(state);
+        const next = applyGeneratedCommand(state, rng);
+        expect(assertGameInvariants(next)).toEqual([]);
+        if (next === state) {
+          expect(JSON.stringify(next)).toBe(before);
+        }
+        state = next;
+      }
+    },
+  );
+
+  it("tracks corruption without allowing negative corruption", () => {
+    const state = createGame("corruption");
+    const added = addCorruption(state, 3);
+    const removed = removeCorruption(added, 99);
+
+    expect(added.corruption.tokens).toBe(3);
+    expect(removed.corruption.tokens).toBe(0);
+    expect(removed.score.shadow).toBeGreaterThanOrEqual(0);
+    expect(assertGameInvariants(removed)).toEqual([]);
+  });
+
+  it("path attack and defense tokens affect path combat scoring", () => {
+    const state = createGame("path-tokens");
+    const withAttack = addActivePathAttackTokens(state, 2);
+    const scoredForShadow = resolveCombat(withAttack);
+
+    const withDefense = addActivePathDefenseTokens(createGame("path-tokens-defense"), 2);
+    const scoredWithDefense = resolveCombat(withDefense);
+
+    expect(scoredForShadow.corruption.tokens).toBeGreaterThanOrEqual(
+      scoredWithDefense.corruption.tokens,
+    );
+    expect(assertGameInvariants(scoredForShadow)).toEqual([]);
+    expect(assertGameInvariants(scoredWithDefense)).toEqual([]);
+  });
+
+  it("activating a replacement path records path history and rejects reuse", () => {
+    const state = createGame("activate-path");
+    const currentNumber = state.activePath?.id === undefined
+      ? 1
+      : eligiblePathsByNumber(state, 1).length > 0
+        ? 1
+        : 2;
+    const replacement = eligiblePathsByNumber(state, currentNumber)[0];
+    expect(replacement).toBeDefined();
+    if (replacement === undefined) {
+      return;
+    }
+
+    const next = activatePathById(state, replacement);
+    expect(next).not.toBeNull();
+    if (next !== null) {
+      expect(next.activePath?.id).toBe(replacement);
+      expect(next.activatedPaths).toContain(replacement);
+      expect(activatePathById(next, replacement)).toBeNull();
+      expect(assertGameInvariants(next)).toEqual([]);
+    }
+  });
+
+  it("queues and resolves typed pending decisions without mutating card locations", () => {
+    const state = createGame("pending-decision");
+    const decision = {
+      type: "forsake" as const,
+      playerId: "frodo" as const,
+      reason: "test decision",
+      minimum: 1,
+      source: "invariant-test",
+    };
+
+    const queued = enqueuePendingDecision(state, decision);
+    const resolved = resolveOldestPendingDecision(queued);
+
+    expect(queued.pendingDecisions).toEqual([decision]);
+    expect(queued.eventLog.at(-1)?.type).toBe("pendingDecisionCreated");
+    expect(resolved.pendingDecisions).toEqual([]);
+    expect(assertGameInvariants(queued)).toEqual([]);
+    expect(assertGameInvariants(resolved)).toEqual([]);
+  });
+});
+
+function applyGeneratedCommand(state: GameState, rng: () => number): GameState {
+  const playerId = state.activePlayer;
+  const player = state.players[playerId];
+  const roll = rng();
+
+  if (roll < 0.18) {
+    return acceptOrKeep(state, tryPass(state));
+  }
+
+  if (roll < 0.36) {
+    const card = choose(player.hand, rng);
+    if (card === null) {
+      return state;
+    }
+    return cycleCard(state, playerId, card);
+  }
+
+  if (roll < 0.55) {
+    const playable = player.hand.find((card) => canPlayTo(state, playerId, card, "reserve"));
+    if (playable === undefined) {
+      return state;
+    }
+    const afterPlay = acceptOrKeep(state, tryPlayCard(state, playerId, playable, "reserve"));
+    return afterPlay === state ? state : nextTurn(afterPlay);
+  }
+
+  if (roll < 0.7) {
+    const first = player.hand[0];
+    const second = player.hand[1];
+    if (first === undefined || second === undefined) {
+      return state;
+    }
+    const afterWinnow = acceptOrKeep(state, tryWinnow(state, playerId, first, second));
+    return afterWinnow === state ? state : nextTurn(afterWinnow);
+  }
+
+  if (roll < 0.82) {
+    const movable = player.reserve.find((card) => {
+      return (
+        !state.roundMemory.playedToReserve.includes(card) &&
+        (tryMoveFromReserve(state, playerId, card, "path").ok ||
+          tryMoveFromReserve(state, playerId, card, "battleground").ok)
+      );
+    });
+    if (movable === undefined) {
+      return state;
+    }
+    const destination = tryMoveFromReserve(state, playerId, movable, "path").ok
+      ? "path"
+      : "battleground";
+    const afterMove = acceptOrKeep(
+      state,
+      tryMoveFromReserve(state, playerId, movable, destination),
+    );
+    return afterMove === state ? state : nextTurn(afterMove);
+  }
+
+  if (roll < 0.92) {
+    return usePlayerRingToken(state, playerId);
+  }
+
+  const illegalPlayer = nextPlayer(playerId);
+  const illegalCard = state.players[illegalPlayer].hand[0] ?? "missing-card";
+  const result = tryPlayCard(state, illegalPlayer, illegalCard, "reserve");
+  expect(result.ok).toBe(false);
+  expect(JSON.stringify(result.state)).toBe(JSON.stringify(state));
+  return state;
+}
+
+function acceptOrKeep(state: GameState, result: CommandResult): GameState {
+  if (!result.ok) {
+    expect(JSON.stringify(result.state)).toBe(JSON.stringify(state));
+    return state;
+  }
+  return result.state;
+}
+
+function choose<T>(items: readonly T[], rng: () => number): T | null {
+  if (items.length === 0) {
+    return null;
+  }
+  return items[Math.floor(rng() * items.length)] ?? null;
+}
+
+function nextPlayer(playerId: PlayerId): PlayerId {
+  switch (playerId) {
+    case "frodo":
+      return "witchKing";
+    case "witchKing":
+      return "aragorn";
+    case "aragorn":
+      return "saruman";
+    case "saruman":
+      return "frodo";
+  }
+}
+
+function seededRng(seed: string): () => number {
+  let hash = 2166136261;
+  for (const char of seed) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return () => {
+    let value = (hash += 0x6d2b79f5);
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/src/invariants.ts
+++ b/src/invariants.ts
@@ -1,0 +1,139 @@
+import { battlegroundDefinitions, pathDefinitions, turnOrder } from "./data";
+import { getCardDefinition, validateState } from "./game";
+import type { GameState } from "./types";
+
+const battlegroundIds: ReadonlySet<string> = new Set(
+  battlegroundDefinitions.map((battleground) => battleground.id),
+);
+const pathIds: ReadonlySet<string> = new Set(pathDefinitions.map((path) => path.id));
+
+export function assertGameInvariants(state: GameState): readonly string[] {
+  const errors: string[] = [...validateState(state)];
+  const allCardIds = new Set(Object.keys(state.cards));
+  const physicalLocations = physicalCardLocations(state);
+
+  for (const instanceId of allCardIds) {
+    if ((physicalLocations.get(instanceId)?.length ?? 0) !== 1) {
+      errors.push(`Card ${instanceId} must have exactly one physical location.`);
+    }
+  }
+
+  for (const [instanceId, locations] of physicalLocations) {
+    if (!allCardIds.has(instanceId)) {
+      errors.push(`Unknown card ${instanceId} appears in ${locations.join(", ")}.`);
+    }
+    if (locations.length > 1) {
+      errors.push(`Card ${instanceId} appears in multiple locations: ${locations.join(", ")}.`);
+    }
+  }
+
+  for (const [wielderId, itemIds] of Object.entries(state.attachments)) {
+    const wielder = state.cards[wielderId];
+    if (wielder === undefined) {
+      continue;
+    }
+    if (getCardDefinition(wielder.cardId).type !== "character") {
+      errors.push(`Attachment wielder ${wielderId} must be a character.`);
+    }
+    for (const itemId of itemIds) {
+      const item = state.cards[itemId];
+      if (item === undefined) {
+        continue;
+      }
+      if (getCardDefinition(item.cardId).type !== "item") {
+        errors.push(`Attached card ${itemId} must be an item.`);
+      }
+    }
+  }
+
+  if (state.corruption.tokens < 0) {
+    errors.push("Corruption cannot be negative.");
+  }
+  if (state.score.free < 0 || state.score.shadow < 0) {
+    errors.push("Scores cannot be negative.");
+  }
+
+  for (const side of ["free", "shadow"] as const) {
+    for (const battlegroundId of state.scoringAreas.battlegrounds[side]) {
+      if (!battlegroundIds.has(battlegroundId)) {
+        errors.push(`Unknown scored battleground: ${battlegroundId}.`);
+      }
+    }
+    for (const path of state.scoringAreas.paths[side]) {
+      if (!pathIds.has(path.id)) {
+        errors.push(`Unknown scored path: ${path.id}.`);
+      }
+      if (path.points < 0) {
+        errors.push(`Scored path ${path.id} has negative points.`);
+      }
+    }
+  }
+
+  const scoredBattlegrounds = [
+    ...state.scoringAreas.battlegrounds.free,
+    ...state.scoringAreas.battlegrounds.shadow,
+  ];
+  if (new Set(scoredBattlegrounds).size !== scoredBattlegrounds.length) {
+    errors.push("A battleground appears in more than one scoring area.");
+  }
+
+  const scoredPaths = [
+    ...state.scoringAreas.paths.free.map((path) => path.id),
+    ...state.scoringAreas.paths.shadow.map((path) => path.id),
+  ];
+  if (new Set(scoredPaths).size !== scoredPaths.length) {
+    errors.push("A path appears in more than one scoring area.");
+  }
+
+  for (const pathId of state.activatedPaths) {
+    if (!pathIds.has(pathId)) {
+      errors.push(`Unknown activated path: ${pathId}.`);
+    }
+  }
+  if (new Set(state.activatedPaths).size !== state.activatedPaths.length) {
+    errors.push("A path was activated more than once.");
+  }
+
+  for (const playerId of turnOrder) {
+    const player = state.players[playerId];
+    if (player.id !== playerId) {
+      errors.push(`Player state ${playerId} has mismatched id ${player.id}.`);
+    }
+  }
+
+  for (const instanceId of state.roundMemory.playedToReserve) {
+    if (!allCardIds.has(instanceId)) {
+      errors.push(`Round memory references unknown reserve card: ${instanceId}.`);
+    }
+  }
+
+  return errors;
+}
+
+function physicalCardLocations(state: GameState): ReadonlyMap<string, readonly string[]> {
+  const locations = new Map<string, string[]>();
+  const add = (instanceId: string, location: string): void => {
+    locations.set(instanceId, [...(locations.get(instanceId) ?? []), location]);
+  };
+
+  for (const playerId of turnOrder) {
+    const player = state.players[playerId];
+    for (const zone of ["draw", "hand", "cycle", "eliminated", "reserve"] as const) {
+      for (const instanceId of player[zone]) {
+        add(instanceId, `${playerId}.${zone}`);
+      }
+    }
+  }
+  for (const instanceId of state.activePath?.cards ?? []) {
+    add(instanceId, `path.${state.activePath?.id ?? "unknown"}`);
+  }
+  for (const instanceId of state.activeBattleground?.cards ?? []) {
+    add(instanceId, `battleground.${state.activeBattleground?.id ?? "unknown"}`);
+  }
+  for (const [wielderId, itemIds] of Object.entries(state.attachments)) {
+    for (const itemId of itemIds) {
+      add(itemId, `attached.${wielderId}`);
+    }
+  }
+  return locations;
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -42,10 +42,26 @@ function isGameState(value: unknown): value is GameState {
 function normalizeGameState(state: GameState): GameState {
   return {
     ...state,
+    activatedPaths: state.activatedPaths ?? [],
+    activePath:
+      state.activePath === null
+        ? null
+        : {
+            ...state.activePath,
+            attackTokens: state.activePath.attackTokens ?? 0,
+            defenseTokens: state.activePath.defenseTokens ?? 0,
+          },
     attachments: state.attachments ?? {},
     roundMemory: state.roundMemory ?? {
       playedToReserve: [],
       playedCharacterOrItemCards: [],
     },
+    pendingDecisions: state.pendingDecisions ?? [],
+    eventLog: state.eventLog ?? [],
+    scoringAreas: state.scoringAreas ?? {
+      battlegrounds: { free: [], shadow: [] },
+      paths: { free: [], shadow: [] },
+    },
+    corruption: state.corruption ?? { tokens: 0 },
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,11 +104,28 @@ export interface PathDefinition {
 export interface ActivePath {
   readonly id: string;
   readonly cards: readonly string[];
+  readonly attackTokens: number;
+  readonly defenseTokens: number;
 }
 
 export interface ScoreState {
   readonly free: number;
   readonly shadow: number;
+}
+
+export interface ScoredPath {
+  readonly id: string;
+  readonly points: number;
+  readonly facedown: boolean;
+}
+
+export interface ScoringAreaState {
+  readonly battlegrounds: Readonly<Record<Side, readonly string[]>>;
+  readonly paths: Readonly<Record<Side, readonly ScoredPath[]>>;
+}
+
+export interface CorruptionState {
+  readonly tokens: number;
 }
 
 export interface LogEntry {
@@ -128,6 +145,56 @@ export interface RoundMemory {
 
 export type AttachmentState = Readonly<Record<string, readonly string[]>>;
 
+export type PendingDecision =
+  | {
+      readonly type: "forsake";
+      readonly playerId: PlayerId;
+      readonly reason: string;
+      readonly minimum: number;
+      readonly source?: string;
+    }
+  | {
+      readonly type: "combatLosses";
+      readonly side: Side;
+      readonly locationType: "path" | "battleground";
+      readonly locationId: string;
+      readonly attackToCancel: number;
+      readonly candidates: readonly string[];
+      readonly source?: string;
+    }
+  | {
+      readonly type: "drawPlayCycleRest";
+      readonly playerId: PlayerId;
+      readonly drawnCards: readonly string[];
+      readonly playableCards: readonly string[];
+      readonly maxPlays: number;
+      readonly source?: string;
+    }
+  | {
+      readonly type: "search";
+      readonly playerId: PlayerId;
+      readonly zones: readonly Zone[];
+      readonly choices: readonly string[];
+      readonly source?: string;
+    };
+
+export type GameEvent =
+  | { readonly type: "cardPlayed"; readonly playerId: PlayerId; readonly cardId: string; readonly destination: PlayDestination }
+  | { readonly type: "cardMoved"; readonly playerId: PlayerId; readonly cardId: string; readonly destination: Exclude<PlayDestination, "reserve"> }
+  | { readonly type: "itemAttached"; readonly playerId: PlayerId; readonly itemId: string; readonly wielderId: string }
+  | { readonly type: "cardCycled"; readonly playerId: PlayerId; readonly cardId: string }
+  | { readonly type: "cardEliminated"; readonly playerId: PlayerId; readonly cardId: string }
+  | { readonly type: "cardsDrawn"; readonly playerId: PlayerId; readonly count: number }
+  | { readonly type: "cardForsaken"; readonly playerId: PlayerId; readonly source: ForsakeSource; readonly cardId?: string }
+  | { readonly type: "playerPassed"; readonly playerId: PlayerId }
+  | { readonly type: "ringTokenUsed"; readonly playerId: PlayerId }
+  | { readonly type: "winnowed"; readonly playerId: PlayerId; readonly cards: readonly string[] }
+  | { readonly type: "roundStarted"; readonly round: number; readonly pathId: string | null; readonly battlegroundId: string | null }
+  | { readonly type: "pathScored"; readonly pathId: string; readonly side: Side; readonly points: number; readonly corruption: number }
+  | { readonly type: "battlegroundScored"; readonly battlegroundId: string; readonly side: Side; readonly points: number }
+  | { readonly type: "corruptionChanged"; readonly delta: number; readonly total: number }
+  | { readonly type: "pendingDecisionCreated"; readonly decision: PendingDecision };
+
 export interface GameState {
   readonly schemaVersion: 1;
   readonly seed: string;
@@ -137,12 +204,17 @@ export interface GameState {
   readonly currentPathNumber: number;
   readonly battlegroundDecks: Readonly<Record<Side, readonly string[]>>;
   readonly pathDeck: readonly string[];
+  readonly activatedPaths: readonly string[];
   readonly activeBattleground: ActiveBattleground | null;
   readonly activePath: ActivePath | null;
   readonly players: Readonly<Record<PlayerId, PlayerState>>;
   readonly cards: Readonly<Record<string, CardInstance>>;
   readonly attachments: AttachmentState;
   readonly roundMemory: RoundMemory;
+  readonly pendingDecisions: readonly PendingDecision[];
+  readonly eventLog: readonly GameEvent[];
+  readonly scoringAreas: ScoringAreaState;
+  readonly corruption: CorruptionState;
   readonly score: ScoreState;
   readonly log: readonly LogEntry[];
   readonly selection: SelectionState;
@@ -171,7 +243,7 @@ export interface RuleViolation {
 }
 
 export type CommandResult =
-  | { readonly ok: true; readonly state: GameState; readonly events: readonly string[] }
+  | { readonly ok: true; readonly state: GameState; readonly events: readonly GameEvent[] }
   | { readonly ok: false; readonly state: GameState; readonly violation: RuleViolation };
 
 export interface GameViewModel {


### PR DESCRIPTION
## Summary
- extend serialized backend state with activated path history, scoring areas, corruption, pending decisions, and typed event log
- add path attack/defense token support and backend primitives for corruption, path activation, and pending-decision queues
- record edge-case/BGG regression backlog as executable registry data
- classify all card/path/battleground text into effect templates for future scripted card effects
- add reusable engine invariant checker
- add seeded fuzz/property tests over generated backend command streams

## Verification
- npm test
- npm run typecheck
- npm run build

## Notes
This implements the backend infrastructure and broad generated coverage from the big edge-case plan. It does not yet fully script every individual card text; the registry/classification keeps those cases explicit and test-addressable.
